### PR TITLE
Fix usage of static tag in 500 template

### DIFF
--- a/portal/templates/500.html
+++ b/portal/templates/500.html
@@ -1,3 +1,4 @@
+{% load staticfiles %}
 <!DOCTYPE html>
 <html><head>
 


### PR DESCRIPTION
Without loading the staticfiles library, `{% static ...%}` causes an exception, masking the real error that triggered the 500 page