### PR TITLE
Changed test_emails to use selenium.

### DIFF
--- a/portal/tests/test_emails.py
+++ b/portal/tests/test_emails.py
@@ -34,16 +34,15 @@
 # copyright notice and these terms. You must not misrepresent the origins of this
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
-from django.test import Client
-from unittest import TestCase
+
 from django.core.urlresolvers import reverse
 from django.core import mail
 
+from base_test import BaseTest
+from django_selenium_clean import selenium
 
-class EmailTest(TestCase):
+
+class EmailTest(BaseTest):
     def test_send_new_users_numbers_email(self):
-        client = Client()
-        response = client.get(reverse('send_new_users_report'))
-        self.assertEqual(response.status_code, 200)
+        selenium.get(self.live_server_url + reverse('send_new_users_report'))
         self.assertEqual(len(mail.outbox), 1)
-        mail.outbox = []

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -98,7 +98,7 @@ urlpatterns = patterns(
     url(r'^admin/map/$', schools_map, name='map'),
     url(r'^admin/data/$', aggregated_data, name='aggregated_data'),
 
-    url(r'^mail/weekly', send_new_users_report, name='send_new_users_report'),
+    url(r'^mail/weekly/', send_new_users_report, name='send_new_users_report'),
 
     url(r'^locked_out/$', TemplateView.as_view(template_name='portal/locked_out.html'),
         name='locked_out'),


### PR DESCRIPTION
This fixes an issue that was causing password reset tests to pass when run alone, but fail when the whole test suite was run.