### PR TITLE
Fix captcha related test bug

### DIFF
--- a/portal/tests/base_test.py
+++ b/portal/tests/base_test.py
@@ -53,8 +53,14 @@ class BaseTest(SeleniumTestCase):
 
     @classmethod
     def setUpClass(cls):
+        cls.orig_captcha_enabled = captcha.CAPTCHA_ENABLED
         captcha.CAPTCHA_ENABLED = False
         super(BaseTest, cls).setUpClass()
+
+    @classmethod
+    def tearDownClass(cls):
+        captcha.CAPTCHA_ENABLED = cls.orig_captcha_enabled
+        super(BaseTest, cls).tearDownClass()
 
     def go_to_homepage(self):
         path = reverse('home')

--- a/portal/tests/test_emails.py
+++ b/portal/tests/test_emails.py
@@ -35,7 +35,7 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 from django.test import Client
-from unittest import TestCase
+from django.test import TestCase
 from django.core.urlresolvers import reverse
 from django.core import mail
 
@@ -46,4 +46,3 @@ class EmailTest(TestCase):
         response = client.get(reverse('send_new_users_report'))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(mail.outbox), 1)
-        mail.outbox = []

--- a/portal/views/registration.py
+++ b/portal/views/registration.py
@@ -44,7 +44,7 @@ from django.contrib.auth import get_user_model
 from two_factor.views import LoginView
 from recaptcha import RecaptchaClient
 from django_recaptcha_field import create_form_subclass_with_recaptcha
-from deploy.captcha import CAPTCHA_ENABLED
+from deploy import captcha
 
 from portal.forms.registration import PasswordResetSetPasswordForm, StudentPasswordResetForm, TeacherPasswordResetForm
 from portal.permissions import not_logged_in, not_fully_logged_in
@@ -82,14 +82,14 @@ def password_reset_check_and_confirm(request, uidb64=None, token=None, post_rese
 
 @user_passes_test(not_logged_in, login_url=reverse_lazy('current_user'))
 def student_password_reset(request, post_reset_redirect):
-    form = StudentPasswordResetForm if not CAPTCHA_ENABLED else decorate_with_captcha(StudentPasswordResetForm, request,
+    form = StudentPasswordResetForm if not captcha.CAPTCHA_ENABLED else decorate_with_captcha(StudentPasswordResetForm, request,
                                                                                    recaptcha_client)
     return password_reset(request, from_email=PASSWORD_RESET_EMAIL, template_name='registration/student_password_reset_form.html', password_reset_form=form, post_reset_redirect=post_reset_redirect, is_admin_site=True)
 
 
 @user_passes_test(not_fully_logged_in, login_url=reverse_lazy('current_user'))
 def teacher_password_reset(request, post_reset_redirect):
-    form = TeacherPasswordResetForm if not CAPTCHA_ENABLED else decorate_with_captcha(TeacherPasswordResetForm, request,
+    form = TeacherPasswordResetForm if not captcha.CAPTCHA_ENABLED else decorate_with_captcha(TeacherPasswordResetForm, request,
                                                                                    recaptcha_client)
     return password_reset(request, from_email=PASSWORD_RESET_EMAIL, template_name='registration/teacher_password_reset_form.html', password_reset_form=form, post_reset_redirect=post_reset_redirect, is_admin_site=True)
 


### PR DESCRIPTION
When the captcha view is imported it was using the then-set value of the CAPTCHA_ENABLED flag.
When the selenium tests ran after a normal TestCase it would already have been imported and thus
not be set up to ignore captchas.