### PR TITLE
Use session storage for messages.

### DIFF
--- a/portal/autoconfig.py
+++ b/portal/autoconfig.py
@@ -77,6 +77,7 @@ SETTINGS = {
     'LANGUAGES': [
         ('en-gb', 'English'),
     ],
+    'MESSAGE_STORAGE': 'django.contrib.messages.storage.session.SessionStorage',
     'MIDDLEWARE_CLASSES': [
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.middleware.locale.LocaleMiddleware',


### PR DESCRIPTION
Pen-testing identified that messages to be displayed after login were stored as HTML in a cookie. This change stores the message in the session (ie server-side).