### PR TITLE
Add authentication checks to reminder cards page

### DIFF
--- a/portal/tests/test_security.py
+++ b/portal/tests/test_security.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+# Code for Life
+#
+# Copyright (C) 2016, Ocado Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ADDITIONAL TERMS – Section 7 GNU General Public Licence
+#
+# This licence does not grant any right, title or interest in any “Ocado” logos,
+# trade names or the trademark “Ocado” or any other trademarks or domain names
+# owned by Ocado Innovation Limited or the Ocado group of companies or any other
+# distinctive brand features of “Ocado” as may be secured from time to time. You
+# must not distribute any modification of this program using the trademark
+# “Ocado” or claim any affiliation or association with Ocado or its employees.
+#
+# You are not authorised to use the name Ocado (or any of its trade names) or
+# the names of any author or contributor in advertising or for publicity purposes
+# pertaining to the distribution of this program, without the prior written
+# authorisation of Ocado.
+#
+# Any propagation, distribution or conveyance of this program must include this
+# copyright notice and these terms. You must not misrepresent the origins of this
+# program; modified versions of the program must be marked as such and not
+# identified as the original program.
+
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import Client, TestCase
+from portal.models import Student, UserProfile
+from utils.classes import create_class_directly
+from utils.teacher import signup_teacher_directly
+
+
+class SecurityTestCase(TestCase):
+
+    def _test_incorrect_teacher_cannot_login(self, view_name):
+        email1, _ = signup_teacher_directly()
+        email2, pass2 = signup_teacher_directly()
+        _, _, access_code = create_class_directly(email1)
+
+        c = Client()
+        c.login(email=email2, password=pass2)
+        page = reverse(view_name, args=[access_code])
+        self.assertNotEqual(c.get(page).status_code, 200)
+
+    def _test_incorrect_teacher_no_info_leak(self, view_name):
+        email1, _ = signup_teacher_directly()
+        email2, pass2 = signup_teacher_directly()
+        _, _, access_code = create_class_directly(email1)
+
+        c = Client()
+        c.login(email=email2, password=pass2)
+
+        invalid_page = reverse(view_name, args=[access_code])
+        invalid_login_code = c.get(invalid_page).status_code
+
+        non_existant_page = reverse(view_name, args=['AAAAA'])
+        non_existant_code = c.get(non_existant_page).status_code
+
+        self.assertEqual(non_existant_code, invalid_login_code)
+
+    def test_reminder_cards_info_leak(self):
+        """Check that it isn't leaked whether an access code exists."""
+        self._test_incorrect_teacher_no_info_leak('teacher_print_reminder_cards')
+
+    def test_class_page_info_leak(self):
+        """Check that it isn't leaked whether an access code exists."""
+        self._test_incorrect_teacher_no_info_leak('teacher_class')
+
+    def test_student_edit_info_leak(self):
+        c = Client()
+        t_email, t_pass = signup_teacher_directly()
+        c.login(email=t_email, password=t_pass)
+        profile = UserProfile(user=User.objects.create_user('test'))
+        profile.save()
+        stu = Student(user=profile)
+        stu.save()
+
+        self.assertEqual(
+            c.get(reverse('teacher_edit_student', kwargs={'pk': '9999'})).status_code,
+            c.get(reverse('teacher_edit_student', kwargs={'pk': stu.pk})).status_code
+        )
+
+    def test_reminder_cards_wrong_teacher(self):
+        """Try and view reminder cards without being the teacher for that class."""
+        self._test_incorrect_teacher_cannot_login('teacher_print_reminder_cards')
+
+    def test_class_page_wrong_teacher(self):
+        """Try and view a class page without being the teacher for that class."""
+        self._test_incorrect_teacher_cannot_login('teacher_class')

--- a/portal/views/teacher/teach.py
+++ b/portal/views/teacher/teach.py
@@ -603,7 +603,10 @@ def teacher_print_reminder_cards(request, access_code):
         character = { 'image': character_image, 'height': character_height, 'width': character_width }
         CHARACTERS.append(character)
 
-    klass = Class.objects.get(access_code=access_code)
+    klass = Class.objects.get_object_or_404(access_code=access_code)
+    # Check auth
+    if klass.Teacher != request.user:
+        raise Http404
 
 
     COLUMN_WIDTH = (CARD_INNER_WIDTH - CARD_IMAGE_WIDTH) * 0.45


### PR DESCRIPTION
Checks that the correct teacher is logged in.
Return the same error code (404) if either the wrong teacher is logged in or if the class the reminder cards are requested for does not exist. This prevents any information being leaked about which classes exist in the database.