### PR TITLE
Move analytics script into head from bottom of the page

### DIFF
--- a/portal/templates/portal/base.html
+++ b/portal/templates/portal/base.html
@@ -50,6 +50,21 @@
 {% block scripts %}
 {% endblock scripts %}
 
+<script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+	
+	
+    ga('create', 'UA-49883146-1', 'auto');
+    ga('send', 'pageview');
+
+</script>
+
+<script src="/static/portal/js/riveted.min.js"></script>
+<script>riveted.init();</script>
+
 </head>
 
 <body>
@@ -155,20 +170,7 @@ $(function() {
 });
 </script>
 
-<script>
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-            m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
-	
-	
-    ga('create', 'UA-49883146-1', 'auto');
-    ga('send', 'pageview');
 
-</script>
-
-<script src="/static/portal/js/riveted.min.js"></script>
-<script>riveted.init();</script>
 
 </body>
 </html>


### PR DESCRIPTION
Placing the analytics code in the head will give more reliable analytics. Leaving it at the end of the body may result it not getting run before the user moves to a different page.