### PR TITLE
Change .zip to .pdf for the pupil certificates.

### DIFF
--- a/portal/templates/portal/teach/teacher_home.html
+++ b/portal/templates/portal/teach/teacher_home.html
@@ -93,7 +93,7 @@
           <td><a href="{% url 'teacher_lesson_plans' %}">Teaching Packs</a></td>
         </tr>
         <tr>
-          <td><a href="{{ 'general_resources/CFL_Pupil_Certificates.zip'|cloud_storage }}" >Pupil Certificates <img src="{% static 'portal/img/zip.png' %}" /></a></td>
+          <td><a href="{{ 'general_resources/CFL_Pupil_Certificates.pdf'|cloud_storage }}" >Pupil Certificates <img src="{% static 'portal/img/pdfsmall.png' %}" /></a></td>
         </tr>
       </table>
   </div>


### PR DESCRIPTION
Currently there are CFL_Pupil_Certificates.zip (old logo, all certificates are separate files zipped together) and CFL_Pupil_Certificates.pdf (new logo all certificates on one pdf) sitting next to each other in the google cloud platform where all teaching materials are stored. This change will update the reference so the new certificates will be accessed.