### PR TITLE
Adding a header blurb for the README - will adapt to other repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 [![Coverage Status](https://coveralls.io/repos/ocadotechnology/codeforlife-portal/badge.svg?branch=master&service=github)](https://coveralls.io/github/ocadotechnology/codeforlife-portal?branch=master)
 [![Code Climate](https://codeclimate.com/github/ocadotechnology/codeforlife-portal/badges/gpa.svg)](https://codeclimate.com/github/ocadotechnology/codeforlife-portal)
 
+## A  [Code for Life](https://www.codeforlife.education/) repository
+* Ocado Technology's [Code for Life initiative](https://www.codeforlife.education/) has been developed to inspire the next generation of computer scientists and to help teachers deliver the computing curriculum.
+* This repository hosts the source code of the **main website**: the portal for the Code For Life initiative, the registration/log in, the teachers' dashboards, the teaching materials, etc
+* The other repos for Code For Life:
+    * the first game, [Rapid Router](https://github.com/ocadotechnology/rapid-router)
+    * the new game for teenagers, [currently at a very early stage](https://github.com/ocadotechnology/aimmo)
+    * the [deployment code for Google App Engine](https://github.com/ocadotechnology/codeforlife-deploy-appengine)
+
 ## Running Locally
 * Clone the repo
 * Make and activate a virtualenv (We recommend [virtualenvwrapper](http://virtualenvwrapper.readthedocs.org/en/latest/index.html))


### PR DESCRIPTION
The idea is to add a "template" like that at the beginning (or elsewhere) of the other open code for life repos here, so we can share the links more confidently at conferences etc, and people understand better the structure of our project on github.
Feel free to comment please! 