### PR TITLE
Redesign 7 - Made base HTML font size responsive

### DIFF
--- a/portal/static/portal/sass/styles.scss
+++ b/portal/static/portal/sass/styles.scss
@@ -43,30 +43,6 @@ $color-background-tint-tertiary: #f8dfe5;
 $color-background-tint-quaternary: #e4eecd;
 $color-background-tint-quinary: #d8d8d8;
 
-@media (min-width: 1200px) {
-  html {
-    font-size: 10px;
-  }
-}
-
-@media (min-width: 992px) and (max-width: 1200px) {
-  html {
-    font-size: 9px;
-  }
-}
-
-@media (min-width: 768px) and (max-width: 992px) {
-  html {
-    font-size: 8px;
-  }
-}
-
-@media (max-width: 768px) {
-  html {
-    font-size: 7px;
-  }
-}
-
 @function calculate-rem($size) {
   $rem-size: $size / 10px;
   @return #{$rem-size}rem;
@@ -1159,6 +1135,10 @@ td {
 
 @media (min-width: 1200px) {
 
+  html {
+    font-size: 10px;
+  }
+
   .hamburger {
     display: none;
   }
@@ -1213,7 +1193,23 @@ td {
 
 }
 
+@media (min-width: 992px) and (max-width: 1200px) {
+  html {
+    font-size: 9px;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 992px) {
+  html {
+    font-size: 8px;
+  }
+}
+
 @media (max-width: 768px) {
+
+  html {
+    font-size: 7px;
+  }
 
   .col-sm-3 {
     width: 50%;

--- a/portal/static/portal/sass/styles.scss
+++ b/portal/static/portal/sass/styles.scss
@@ -43,6 +43,30 @@ $color-background-tint-tertiary: #f8dfe5;
 $color-background-tint-quaternary: #e4eecd;
 $color-background-tint-quinary: #d8d8d8;
 
+@media (min-width: 1200px) {
+  html {
+    font-size: 10px;
+  }
+}
+
+@media (min-width: 992px) and (max-width: 1200px) {
+  html {
+    font-size: 9px;
+  }
+}
+
+@media (min-width: 768px) and (max-width: 992px) {
+  html {
+    font-size: 8px;
+  }
+}
+
+@media (max-width: 768px) {
+  html {
+    font-size: 7px;
+  }
+}
+
 @function calculate-rem($size) {
   $rem-size: $size / 10px;
   @return #{$rem-size}rem;
@@ -1189,7 +1213,7 @@ td {
 
 }
 
-@media (max-width: 630px) {
+@media (max-width: 768px) {
 
   .col-sm-3 {
     width: 50%;

--- a/portal/templates/redesign/base_new.html
+++ b/portal/templates/redesign/base_new.html
@@ -13,6 +13,7 @@
 
     <title>{% block title %}Code for Life{% endblock %}</title>
     <meta name="msapplication-config" content="none"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
 
     {% block head %}
     {% endblock head %}


### PR DESCRIPTION
In the new styles.scss file, all font sizes for text, buttons, etc... are converted from pxs to rems. Rems are relative to the root HTML font size. Therefore added some media queries in styles.scss file so that every element's font size would be updated responsively.
The different widths used in the media queries follow [Bootstrap's tutorial](http://getbootstrap.com/css/#grid-media-queries).