### PR TITLE
Redesign 15 - Teacher dashboard forms

### DIFF
--- a/portal/emailMessages_new.py
+++ b/portal/emailMessages_new.py
@@ -58,7 +58,7 @@ def emailChangeVerificationEmail(request, token):
     return {
         'subject': emailSubjectPrefix() + " : Email address verification needed",
         'message': ("You are changing your email, please go to " +
-                    request.build_absolute_uri(reverse('verify_email', kwargs={'token': token})) +
+                    request.build_absolute_uri(reverse('change_email', kwargs={'token': token})) +
                     " to verify your new email address. If you are not part of Code for Life " +
                     "then please ignore this email. " + emailBodySignOff(request)),
     }
@@ -69,120 +69,6 @@ def emailChangeNotificationEmail(request, new_email):
         'subject': emailSubjectPrefix() + " : Email address changed",
         'message': ("Someone has tried to change the email address of your account. If this was " +
                     "not you, please get in contact with us via " +
-                    request.build_absolute_uri(reverse('contact')) + "." +
+                    request.build_absolute_uri(reverse('help_new')) + "#contact ." +
                     emailBodySignOff(request)),
-    }
-
-
-def joinRequestPendingEmail(request, pendingAddress):
-    return {
-        'subject': emailSubjectPrefix() + " : School or club join request pending",
-        'message': ("Someone with the email address '" + pendingAddress +
-                    "' has asked to join your school or club, please go to " +
-                    request.build_absolute_uri(reverse('organisation_manage')) +
-                    " to view the pending join request." + emailBodySignOff(request)),
-    }
-
-
-def joinRequestSentEmail(request, schoolName):
-    return {
-        'subject': emailSubjectPrefix() + " : School or club join request sent",
-        'message': ("Your request to join the school or club '" + schoolName +
-                    "' has been sent. Someone will either accept or deny your request soon." +
-                    emailBodySignOff(request)),
-    }
-
-
-def joinRequestAcceptedEmail(request, schoolName):
-    return {
-        'subject': emailSubjectPrefix() + " : School or club join request accepted",
-        'message': ("Your request to join the school or club '" + schoolName +
-                    "' has been accepted." + emailBodySignOff(request)),
-    }
-
-
-def joinRequestDeniedEmail(request, schoolName):
-    return {
-        'subject': emailSubjectPrefix() + " : School or club join request denied",
-        'message': ("Your request to join the school or club '" + schoolName +
-                    "' has been denied. If you think this was in error you should speak to the " +
-                    "administrator of that school or club." + emailBodySignOff(request)),
-    }
-
-
-def kickedEmail(request, schoolName):
-    return {
-        'subject': emailSubjectPrefix() + " : You were removed from your school or club",
-        'message': ("You have been removed from the school or club '" + schoolName +
-                    "'. If you think this was in error, please contact the administrator of that " +
-                    "school or club."),
-    }
-
-
-def adminGivenEmail(request, schoolName):
-    return {
-        'subject': emailSubjectPrefix() + " : You have been made a school or club administrator",
-        'message': ("Administrator control of the school or club '" + schoolName +
-                    "' has been given to you. Go to " +
-                    request.build_absolute_uri(reverse('organisation_manage')) +
-                    " to start managing your school or club." + emailBodySignOff(request)),
-    }
-
-
-def adminRevokedEmail(request, schoolName):
-    return {
-        'subject': emailSubjectPrefix() + " : You are no longer a school or club administrator",
-        'message': ("Your administrator control of the school or club '" + schoolName +
-                    "' has been revoked. If you think this is in error, please contact one of " +
-                    "the other administrators in your school or club." +
-                    emailBodySignOff(request)),
-    }
-
-
-def contactEmail(request, name, telephone, email, message, browser):
-    return {
-        'subject': emailSubjectPrefix() + " : Contact from Portal",
-        'message': (("The following message has been submitted on the Code for Life portal:" +
-                     "\n\nName: {name}\nTelephone: {telephone}\nEmail: {email}\n\nMessage:" +
-                     "\n{message}\n\nBrowser version data received:\n{browser}").format(
-            name=name, telephone=telephone, email=email, message=message, browser=browser)),
-    }
-
-
-def confirmationContactEmailMessage(request, name, telephone, email, message):
-    return {
-        'subject': emailSubjectPrefix() + " : Your message has been sent",
-        'message': ("Your message has been sent to our Code for Life team who will get back to you " +
-                    "as soon as possible.\n\nYour message is shown below." +
-                    emailBodySignOff(request) +
-                    ("\n\nName: {name}\nTelephone: {telephone}\nEmail: {email}\n\nMessage:" +
-                     "\n{message}").format(name=name, telephone=telephone, email=email, message=message)),
-    }
-
-
-def studentJoinRequestSentEmail(request, schoolName, accessCode):
-    return {
-        'subject': emailSubjectPrefix() + " : School or club join request sent",
-        'message': ("Your request to join the school or club '" + schoolName + "' in class " +
-                    accessCode + " has been sent to that class's teacher, who will either accept " +
-                    "or deny your request." + emailBodySignOff(request)),
-    }
-
-
-def studentJoinRequestNotifyEmail(request, username, email, accessCode):
-    return {
-        'subject': emailSubjectPrefix() + " : School or club join request by student " + username,
-        'message': ("There is a request waiting from student with username '" + username +
-                    "' and email " + email + " to join your class " + accessCode + ". Go to " +
-                    request.build_absolute_uri(reverse('teacher_classes')) +
-                    " to review the request." + emailBodySignOff(request)),
-    }
-
-
-def studentJoinRequestRejectedEmail(request, schoolName, accessCode):
-    return {
-        'subject': emailSubjectPrefix() + " : School or club join request rejected",
-        'message': ("Your request to join the school or club '" + schoolName + "' in class " +
-                    accessCode + " has been rejected. Speak to your teacher if you think this is " +
-                    "in error." + emailBodySignOff(request)),
     }

--- a/portal/forms/teach.py
+++ b/portal/forms/teach.py
@@ -252,15 +252,10 @@ class ClassEditForm(forms.Form):
     join_choices = [('', "Don't change my current setting"),
                     ('0', "Don't allow external requests to this class"),
                     ('1', "Allow external requests to this class for the next hour")]
-    for i in range(6):
-        hours = 4 * (i + 1)
-        join_choices.append((str(hours), "Allow external requests to this class for the next "
-                             + str(hours) + " hours"))
-    for i in range(4):
-        days = i + 2
-        hours = days * 24
-        join_choices.append((str(hours), "Allow external requests to this class for the next "
-                            + str(days) + " days"))
+    join_choices.extend([(str(hours), "Allow external requests to this class for the next " + str(hours) + " hours")
+                         for hours in range(4, 24, 4)])
+    join_choices.extend([(str(days*24), "Allow external requests to this class for the next " + str(days) + " days")
+                         for days in range(2, 5)])
     join_choices.append(('1000', "Always allow external requests to this class (not recommended)"))
     name = forms.CharField(
         label='Class Name',

--- a/portal/forms/teach_new.py
+++ b/portal/forms/teach_new.py
@@ -1,0 +1,519 @@
+# -*- coding: utf-8 -*-
+# Code for Life
+#
+# Copyright (C) 2016, Ocado Innovation Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ADDITIONAL TERMS – Section 7 GNU General Public Licence
+#
+# This licence does not grant any right, title or interest in any “Ocado” logos,
+# trade names or the trademark “Ocado” or any other trademarks or domain names
+# owned by Ocado Innovation Limited or the Ocado group of companies or any other
+# distinctive brand features of “Ocado” as may be secured from time to time. You
+# must not distribute any modification of this program using the trademark
+# “Ocado” or claim any affiliation or association with Ocado or its employees.
+#
+# You are not authorised to use the name Ocado (or any of its trade names) or
+# the names of any author or contributor in advertising or for publicity purposes
+# pertaining to the distribution of this program, without the prior written
+# authorisation of Ocado.
+#
+# Any propagation, distribution or conveyance of this program must include this
+# copyright notice and these terms. You must not misrepresent the origins of this
+# program; modified versions of the program must be marked as such and not
+# identified as the original program.
+import re
+
+from django import forms
+from django.contrib.auth import authenticate
+from django.contrib.auth.models import User
+
+from portal.models import Student, Teacher, stripStudentName
+from portal.helpers.password import password_strength_test
+
+
+choices = [('Miss', 'Miss'), ('Mrs', 'Mrs'), ('Ms', 'Ms'), ('Mr', 'Mr'),
+           ('Dr', 'Dr'), ('Rev', 'Rev'), ('Sir', 'Sir'), ('Dame', 'Dame')]
+
+
+class TeacherSignupForm(forms.Form):
+
+    title = forms.ChoiceField(
+        label='Title',
+        choices=choices,
+        widget=forms.Select(
+            attrs={
+                'class': 'wide'
+            }
+        )
+    )
+    first_name = forms.CharField(
+        label='First name',
+        max_length=100,
+        widget=forms.TextInput(
+            attrs={
+                'placeholder': 'Grace'
+            }
+        )
+    )
+    last_name = forms.CharField(
+        label='Last name',
+        max_length=100,
+        widget=forms.TextInput(
+            attrs={
+                'placeholder': 'Hopper'
+            }
+        )
+    )
+    email = forms.EmailField(
+        label='Email address',
+        widget=forms.EmailInput(
+            attrs={
+                'placeholder': 'grace.hopper@navy.mil'
+            }
+        )
+    )
+    password = forms.CharField(
+        label='Password',
+        widget=forms.PasswordInput()
+    )
+    confirm_password = forms.CharField(
+        label='Confirm Password',
+        widget=forms.PasswordInput()
+    )
+
+    def clean_email(self):
+        email = self.cleaned_data.get('email', None)
+
+        if email and Teacher.objects.filter(new_user__email=email).exists():
+            raise forms.ValidationError("That email address is already in use")
+
+        return email
+
+    def clean_password(self):
+        password = self.cleaned_data.get('password', None)
+
+        if password and not password_strength_test(password):
+            raise forms.ValidationError(
+                "Password not strong enough, consider using at least 8 characters, upper and lower " + "case letters, and numbers")
+
+        return password
+
+    def clean(self):
+        if any(self.errors):
+            return
+
+        password = self.cleaned_data.get('password', None)
+        confirm_password = self.cleaned_data.get('confirm_password', None)
+
+        if password and confirm_password and password != confirm_password:
+            raise forms.ValidationError('Your passwords do not match')
+
+        return self.cleaned_data
+
+
+class TeacherEditAccountForm(forms.Form):
+
+    title = forms.ChoiceField(
+        label='Title', choices=choices,
+        widget=forms.Select(attrs={'placeholder': "Title", 'class': 'wide'}))
+    first_name = forms.CharField(
+        label='First name', max_length=100,
+        widget=forms.TextInput(attrs={'placeholder': "First name", 'class': 'fName'}))
+    last_name = forms.CharField(
+        label='Last name', max_length=100,
+        widget=forms.TextInput(attrs={'placeholder': "Last name", 'class': 'lName'}))
+    email = forms.EmailField(
+        label='Change email address (optional)', required=False,
+        widget=forms.EmailInput(attrs={'placeholder': "new.email@address.com"}))
+    password = forms.CharField(
+        label='New password (optional)', required=False,
+        widget=forms.PasswordInput)
+    confirm_password = forms.CharField(
+        label='Confirm new password', required=False,
+        widget=forms.PasswordInput)
+    current_password = forms.CharField(
+        label='Current password',
+        widget=forms.PasswordInput)
+
+    def __init__(self, user, *args, **kwargs):
+        self.user = user
+        super(TeacherEditAccountForm, self).__init__(*args, **kwargs)
+
+    def clean_email(self):
+        email = self.cleaned_data.get('email', None)
+        if email:
+            teachers = Teacher.objects.filter(new_user__email=email)
+            if ((len(teachers) == 1 and teachers[0].new_user != self.user) or
+                    len(teachers) > 1):
+                raise forms.ValidationError("That email address is already in use")
+
+        return email
+
+    def clean_password(self):
+        password = self.cleaned_data.get('password', None)
+
+        if password and not password_strength_test(password):
+            raise forms.ValidationError(
+                "Password not strong enough, consider using at least 8 characters, upper and lower " + "case letters, and numbers")
+
+        return password
+
+    def clean(self):
+        if any(self.errors):
+            return
+
+        password = self.cleaned_data.get('password', None)
+        confirm_password = self.cleaned_data.get('confirm_password', None)
+        current_password = self.cleaned_data.get('current_password', None)
+
+        self.check_password_errors(password, confirm_password, current_password)
+
+        return self.cleaned_data
+
+    def check_password_errors(self, password, confirm_password, current_password):
+        if (password or confirm_password) and password != confirm_password:
+            raise forms.ValidationError('Your new passwords do not match')
+
+        if not self.user.check_password(current_password):
+            raise forms.ValidationError('Your current password was incorrect')
+
+
+class TeacherLoginForm(forms.Form):
+    email = forms.EmailField(
+        label='Email address',
+        widget=forms.EmailInput(attrs={'placeholder': "my.email@address.com"}))
+    password = forms.CharField(
+        label='Password',
+        widget=forms.PasswordInput)
+
+    def clean(self):
+        if self.has_error('recaptcha'):
+            raise forms.ValidationError('Incorrect email address, password or captcha')
+
+        email = self.cleaned_data.get('email', None)
+        password = self.cleaned_data.get('password', None)
+
+        if email and password:
+
+            # Check it's a teacher and not a student using the same email address
+            user = None
+
+            user = self.find_user(email, user)
+
+            user = authenticate(username=user.username, password=password)
+
+            self.check_email_erros(user)
+
+            self.user = user
+
+        return self.cleaned_data
+
+    def find_user(self, email, user):
+        users = User.objects.filter(email=email)
+
+        for result in users:
+            if hasattr(result, 'userprofile') and hasattr(result.userprofile, 'teacher'):
+                user = result
+                break
+
+        if user is None:
+            raise forms.ValidationError('Incorrect email address or password')
+
+        return user
+
+    def check_email_erros(self, user):
+        if user is None:
+            raise forms.ValidationError('Incorrect email address or password')
+
+        if not user.is_active:
+            raise forms.ValidationError('User account has been deactivated')
+
+
+class ClassCreationForm(forms.Form):
+    classmate_choices = [('True', 'Yes'), ('False', 'No')]
+    class_name = forms.CharField(
+        label='Class Name',
+        widget=forms.TextInput(attrs={'placeholder': 'Lower KS2'}))
+    classmate_progress = forms.ChoiceField(
+        label="Allow students to see their classmates' progress?",
+        choices=classmate_choices,
+        widget=forms.Select(attrs={'class': 'wide'}))
+
+
+class ClassEditForm(forms.Form):
+    classmate_choices = [('True', 'Yes'), ('False', 'No')]
+    # select dropdown choices for potentially limiting time in which external students may join
+    # class
+    # 0 value = don't allow
+    # n value = allow for next n hours, n < 1000 hours
+    # o/w = allow forever
+    join_choices = [('', "Don't change my current setting"),
+                    ('0', "Don't allow external requests to this class"),
+                    ('1', "Allow external requests to this class for the next hour")]
+    for i in range(6):
+        hours = 4 * (i + 1)
+        join_choices.append((str(hours), "Allow external requests to this class for the next " + str(hours) + " hours"))
+    for i in range(4):
+        days = i + 2
+        hours = days * 24
+        join_choices.append((str(hours), "Allow external requests to this class for the next " + str(days) + " days"))
+    join_choices.append(('1000', "Always allow external requests to this class (not recommended)"))
+    name = forms.CharField(
+        label='Class Name',
+        widget=forms.TextInput(attrs={'placeholder': 'Class Name'}))
+    classmate_progress = forms.ChoiceField(
+        label="Allow students to see their classmates' progress?",
+        choices=classmate_choices, widget=forms.Select(attrs={'class': 'wide'}))
+    external_requests = forms.ChoiceField(
+        label="Set up external requests to this class", required=False, choices=join_choices,
+        widget=forms.Select(attrs={'class': 'wide'}))
+
+
+class ClassMoveForm(forms.Form):
+    new_teacher = forms.ChoiceField(label='Teachers', widget=forms.Select(attrs={'class': 'wide'}))
+
+    def __init__(self, teachers, *args, **kwargs):
+        self.teachers = teachers
+        teacher_choices = []
+        for teacher in teachers:
+            teacher_choices.append((teacher.id, teacher.new_user.first_name + ' ' + teacher.new_user.last_name))
+        super(ClassMoveForm, self).__init__(*args, **kwargs)
+        self.fields['new_teacher'].choices = teacher_choices
+
+
+class TeacherEditStudentForm(forms.Form):
+    name = forms.CharField(label='Name', widget=forms.TextInput(attrs={'placeholder': 'Name'}))
+
+    def __init__(self, student, *args, **kwargs):
+        self.student = student
+        self.klass = student.class_field
+        super(TeacherEditStudentForm, self).__init__(*args, **kwargs)
+
+    def clean_name(self):
+        name = stripStudentName(self.cleaned_data.get('name', ''))
+
+        if name == '':
+            raise forms.ValidationError("'" + self.cleaned_data.get('name', '') + "' is not a valid name")
+
+        students = Student.objects.filter(class_field=self.klass,
+                                          new_user__first_name__iexact=name)
+        if students.exists() and students[0] != self.student:
+            raise forms.ValidationError("There is already a student called '" + name + "' in this class")
+
+        return name
+
+
+class TeacherSetStudentPass(forms.Form):
+    password = forms.CharField(
+        label='New password',
+        widget=forms.PasswordInput(attrs={'placeholder': "New password"}))
+    confirm_password = forms.CharField(
+        label='Confirm new password',
+        widget=forms.PasswordInput(attrs={'placeholder': "Confirm new password"}))
+
+    def clean_password(self):
+        password = self.cleaned_data.get('password', None)
+
+        if password and not password_strength_test(password, length=6, upper=False, lower=False,
+                                                   numbers=False):
+            raise forms.ValidationError(
+                "Password not strong enough, consider using at least 6 characters")
+
+        return password
+
+    def clean(self):
+        password = self.cleaned_data.get('password', None)
+        confirm_password = self.cleaned_data.get('confirm_password', None)
+
+        if password is not None and (password or confirm_password) and password != confirm_password:
+            raise forms.ValidationError('The new passwords do not match')
+
+        return self.cleaned_data
+
+
+class TeacherAddExternalStudentForm(forms.Form):
+    name = forms.CharField(
+        label='Student name',
+        widget=forms.TextInput(attrs={'placeholder': 'Name'}))
+
+    def __init__(self, klass, *args, **kwargs):
+        self.klass = klass
+        super(TeacherAddExternalStudentForm, self).__init__(*args, **kwargs)
+
+    def clean_name(self):
+        name = stripStudentName(self.cleaned_data.get('name', ''))
+
+        if name == '':
+            raise forms.ValidationError("'" + self.cleaned_data.get('name', '') + "' is not a valid name")
+
+        if Student.objects.filter(
+                class_field=self.klass, new_user__first_name__iexact=name).exists():
+            raise forms.ValidationError("There is already a student called '" + name + "' in this class")
+
+        return name
+
+
+class TeacherMoveStudentsDestinationForm(forms.Form):
+    new_class = forms.ChoiceField(label='Choose a new class from the drop down menu for the selected students.', widget=forms.Select(attrs={'class': 'wide'}))
+
+    def __init__(self, classes, *args, **kwargs):
+        self.classes = classes
+        class_choices = []
+        for klass in classes:
+            class_choices.append((klass.id, klass.name + ' (' + klass.access_code + '), ' + klass.teacher.new_user.first_name + ' ' + klass.teacher.new_user.last_name))
+        super(TeacherMoveStudentsDestinationForm, self).__init__(*args, **kwargs)
+        self.fields['new_class'].choices = class_choices
+
+
+class TeacherMoveStudentDisambiguationForm(forms.Form):
+    orig_name = forms.CharField(
+        label='Original Name',
+        widget=forms.TextInput(
+            attrs={'readonly': 'readonly', 'placeholder': 'Original Name', 'type': 'hidden'}))
+    name = forms.CharField(
+        label='Name',
+        widget=forms.TextInput(attrs={'placeholder': 'Name', 'style': 'margin : 0px'}))
+
+    def clean_name(self):
+        name = stripStudentName(self.cleaned_data.get('name', ''))
+        if name == '':
+            raise forms.ValidationError("'" + self.cleaned_data.get('name', '') + "' is not a valid name")
+        return name
+
+
+def validateStudentNames(klass, names):
+    validationErrors = []
+
+    if klass:
+        # We want to report if a student already exists with that name.
+        # But only report each name once if there are duplicates.
+        students = Student.objects.filter(class_field=klass)
+        clashes_found = []
+        find_clashes(names, students, clashes_found, validationErrors)
+
+    # Also report if a student appears twice in the list to be added.
+    # But again only report each name once.
+    lower_names = [name.lower() for name in names]
+    find_duplicates(names, lower_names, validationErrors)
+
+    return validationErrors
+
+
+def find_clashes(names, students, clashes_found, validationErrors):
+    for name in names:
+        if (students.filter(new_user__first_name__iexact=name).exists() and name not in clashes_found):
+            validationErrors.append(forms.ValidationError("There is already a student called '" + name + "' in this class"))
+            clashes_found.append(name)
+
+
+def find_duplicates(names, lower_names, validationErrors):
+    duplicates_found = []
+    for duplicate in [name for name in names if lower_names.count(name.lower()) > 1]:
+        if duplicate not in duplicates_found:
+            validationErrors.append(forms.ValidationError(
+                "You cannot add more than one student called '" + duplicate + "'"))
+            duplicates_found.append(duplicate)
+
+
+class BaseTeacherMoveStudentsDisambiguationFormSet(forms.BaseFormSet):
+    def __init__(self, destination, *args, **kwargs):
+        self.destination = destination
+        super(BaseTeacherMoveStudentsDisambiguationFormSet, self).__init__(*args, **kwargs)
+
+    def clean(self):
+        if any(self.errors):
+            return
+
+        names = [form.cleaned_data['name'] for form in self.forms]
+
+        validationErrors = validateStudentNames(self.destination, names)
+
+        if len(validationErrors) > 0:
+            raise forms.ValidationError(validationErrors)
+
+        self.strippedNames = names
+
+
+class TeacherDismissStudentsForm(forms.Form):
+    orig_name = forms.CharField(
+        label='Original Name',
+        widget=forms.TextInput(
+            attrs={'readonly': 'readonly', 'placeholder': 'Original Name', 'type': 'hidden'}))
+    name = forms.CharField(
+        label='New Name',
+        widget=forms.TextInput(attrs={'placeholder': 'New Name', 'style': 'margin : 0px'}))
+    email = forms.EmailField(
+        label='Email',
+        widget=forms.EmailInput(attrs={'placeholder': 'Email Address', 'style': 'margin : 0px'}))
+    confirm_email = forms.EmailField(
+        label='Confirm Email',
+        widget=forms.EmailInput(
+            attrs={'placeholder': 'Confirm Email Address', 'style': 'margin : 0px'}))
+
+    def clean_name(self):
+        name = stripStudentName(self.cleaned_data.get('name', ''))
+
+        if name == '':
+            raise forms.ValidationError("'" + self.cleaned_data.get('name', '') + "' is not a valid name")
+
+        if User.objects.filter(username=name).exists():
+            raise forms.ValidationError('That username is already in use')
+
+        return name
+
+    def clean(self):
+        email = self.cleaned_data.get('email', None)
+        confirm_email = self.cleaned_data.get('confirm_email', None)
+
+        if (email or confirm_email) and email != confirm_email:
+            raise forms.ValidationError('Your new emails do not match')
+
+        return self.cleaned_data
+
+
+class BaseTeacherDismissStudentsFormSet(forms.BaseFormSet):
+    def clean(self):
+        if any(self.errors):
+            return
+
+        names = [form.cleaned_data['name'] for form in self.forms]
+
+        validationErrors = validateStudentNames(None, names)
+
+        if len(validationErrors) > 0:
+            raise forms.ValidationError(validationErrors)
+
+
+class StudentCreationForm(forms.Form):
+    names = forms.CharField(label='names', widget=forms.Textarea)
+
+    def __init__(self, klass, *args, **kwargs):
+        self.klass = klass
+        super(StudentCreationForm, self).__init__(*args, **kwargs)
+
+    def clean(self):
+        names = re.split(';|,|\n', self.cleaned_data.get('names', ''))
+        names = map(stripStudentName, names)
+        names = [name for name in names if name != '']
+
+        validationErrors = validateStudentNames(self.klass, names)
+
+        if len(validationErrors) > 0:
+            raise forms.ValidationError(validationErrors)
+
+        self.strippedNames = names
+
+        return self.cleaned_data

--- a/portal/forms/teach_new.py
+++ b/portal/forms/teach_new.py
@@ -263,11 +263,10 @@ class ClassEditForm(forms.Form):
     join_choices = [('', "Don't change my current setting"),
                     ('0', "Don't allow external requests to this class"),
                     ('1', "Allow external requests to this class for the next hour")]
-    for hours in range(4, 24, 4):
-        join_choices.append((str(hours), "Allow external requests to this class for the next " + str(hours) + " hours"))
-    for days in range(2, 5):
-        hours = days * 24
-        join_choices.append((str(hours), "Allow external requests to this class for the next " + str(days) + " days"))
+    join_choices.extend([(str(hours), "Allow external requests to this class for the next " + str(hours) + " hours")
+                         for hours in range(4, 24, 4)])
+    join_choices.extend([(str(days*24), "Allow external requests to this class for the next " + str(days) + " days")
+                         for days in range(2, 5)])
     join_choices.append(('1000', "Always allow external requests to this class (not recommended)"))
     name = forms.CharField(
         label='Class Name',

--- a/portal/forms/teach_new.py
+++ b/portal/forms/teach_new.py
@@ -263,11 +263,9 @@ class ClassEditForm(forms.Form):
     join_choices = [('', "Don't change my current setting"),
                     ('0', "Don't allow external requests to this class"),
                     ('1', "Allow external requests to this class for the next hour")]
-    for i in range(6):
-        hours = 4 * (i + 1)
+    for hours in range(4, 24, 4):
         join_choices.append((str(hours), "Allow external requests to this class for the next " + str(hours) + " hours"))
-    for i in range(4):
-        days = i + 2
+    for days in range(2, 5):
         hours = days * 24
         join_choices.append((str(hours), "Allow external requests to this class for the next " + str(days) + " days"))
     join_choices.append(('1000', "Always allow external requests to this class (not recommended)"))

--- a/portal/helpers/emails_new.py
+++ b/portal/helpers/emails_new.py
@@ -45,8 +45,8 @@ from django.template import Context, loader
 from portal.models import EmailVerification
 from portal import app_settings
 from portal.emailMessages_new import emailVerificationNeededEmail
-from portal.emailMessages import emailChangeNotificationEmail
-from portal.emailMessages import emailChangeVerificationEmail
+from portal.emailMessages_new import emailChangeNotificationEmail
+from portal.emailMessages_new import emailChangeVerificationEmail
 
 NOTIFICATION_EMAIL = 'Code For Life Notification <' + app_settings.EMAIL_ADDRESS + '>'
 VERIFICATION_EMAIL = 'Code For Life Verification <' + app_settings.EMAIL_ADDRESS + '>'

--- a/portal/static/portal/sass/styles.scss
+++ b/portal/static/portal/sass/styles.scss
@@ -7,6 +7,8 @@ $color-text-grey: #4a4a4a;
 $color-text-primary: #000;
 $color-text-secondary: #fff;
 $color-text-tertiary: $color-text-grey;
+$color-text-form-error: #f00;
+$color-text-login-error: #ff0;
 //Quotes
 $color-quote-text: $color-teacher-blue;
 $color-quote-name: $color-text-grey;
@@ -710,6 +712,14 @@ form {
     width: 100%;
   }
 
+  ul {
+    color: $color-text-form-error;
+    font-style: italic;
+    list-style: none;
+    padding: 0;
+    text-align: left;
+  }
+
 }
 
 .form--register {
@@ -735,7 +745,7 @@ form {
   }
 
   ul {
-    color: yellow;
+    color: $color-text-login-error;
     font-style: italic;
     list-style: none;
     padding: 0;

--- a/portal/templates/redesign/teach_new/dashboard.html
+++ b/portal/templates/redesign/teach_new/dashboard.html
@@ -55,7 +55,7 @@
 
 <div id="school">
     <section class="background">
-        <h2>Your school: {% if user.new_teacher.school %} {{ user.new_teacher.school.name }}{% endif %}</h2>
+        <h2>Your school: {% if user.new_teacher.school %} {{ user.new_teacher.school.name }} ({{ user.new_teacher.school.postcode }}){% endif %}</h2>
         {% if is_admin %}
             <h4 class="col-sm-6 col-center">As an administrator of your school or club, you can select other teachers to whom you can provide or revoke
                 administrative rights. You can also remove teachers from your school or club if they leave, and respond to requests from new teachers
@@ -140,23 +140,20 @@
             <h3>Change details of your school or club</h3>
             <p class="body-text">Update your school or club&rsquo;s name and/or postcode.
             <strong>These details are used to allow other teachers to join your team.</strong></p>
-            <form>
-                <div class="row">
-                    <div class="col-sm-4">
-                        <p class="body-text">Name of your school or club</p>
-                        <input type="text" placeholder="A School">
-                    </div>
-                    <div class="col-sm-4">
-                        <p class="body-text">Postcode</p>
-                        <input type="text" placeholder="HP99 1BB">
-                    </div>
-                    <div class="col-sm-4">
-                        <p class="body-text">Country</p>
-                        <input type="text" placeholder="United Kingdom">
-                    </div>
+            <form id="edit_form" method='post'>
+                {% csrf_token %}
+
+                {{ update_school_form.non_field_errors }}
+
+                {% for field in update_school_form %}
+                <label for="id_{{ field.html_name }}">{{ field.label }}</label>
+                {{ field }}
+                {{ field.errors }}
+                {% endfor %}
+                <div class='section group'>
+                    <button id="update_details_button" type='submit' class='button--regular button--primary--general-play' name="update_school">Change</button>
                 </div>
             </form>
-            <button class="button--regular button--primary--general-play">Change</button>
         </div>
     </div>
 </div>
@@ -206,18 +203,27 @@
             <h3>Create a new class</h3>
             <p class="body-text">When you set up a new class, a unique class access code will automatically be generated, with you being identified as the teacher for that
                 class.</p>
-            <form>
-                <div class="row row--under">
-                    <div class="col-sm-6">
-                        <input type="text" name="FirstName" value="" placeholder="Enter a class name">
-                        <div class="row">
-                            <p class="small-text col-sm-8">Allow students to see their classmates&rsquo; progress?</p>
-                            <input class="col-sm-1" type="checkbox" name="vehicle" value="">
-                        </div>
+            <form method='post'>
+
+                {% csrf_token %}
+
+                {{ create_class_form.non_field_errors }}
+
+                <div class="section group">
+
+                    <label for="id_{{ form.class_name.html_name }}">{{ create_class_form.class_name.label }}</label>
+                    {{ create_class_form.class_name }}
+                    {{ create_class_form.class_name.errors }}
+                    <div class="col span_1_of_3">
+                        <label for="id_{{ form.classmate_progress.html_name }}">{{ create_class_form.classmate_progress.label }}</label>
                     </div>
+                    <div class="col span_1_of_3">
+                        {{ create_class_form.classmate_progress }}
+                        {{ create_class_form.classmate_progress.errors }}
+                    </div>
+                    <button id="create_class_button" type='submit' class='button--regular button--primary--positive' name="create_class">Create</button>
                 </div>
             </form>
-            <button class="button--regular button--primary--positive">Create class</button>
         </div>
     </div>
 </div>
@@ -231,43 +237,55 @@
     <div class="background background--tertiary">
         <div class="col-sm-7 col-center">
             <h3>Update details</h3>
-            <form>
+            <form method='post' id="form-edit-teacher">
+
+                {% csrf_token %}
+
+                {{ update_account_form.non_field_errors }}
+
                 <div class="row row--under">
                     <div class="col-sm-2">
-                        <p class="body-text">Title</p>
-                        <input type="text">
+                        <label for="id_{{ form.title.html_name }}">{{ update_account_form.title.label }}</label>
+                        {{ update_account_form.title }}
+                        {{ update_account_form.title.errors }}
                     </div>
                     <div class="col-sm-5">
-                        <p class="body-text">First name</p>
-                        <input type="text">
+                        <label for="id_{{ form.first_name.html_name }}">{{ update_account_form.first_name.label }}</label>
+                        {{ update_account_form.first_name }}
+                        {{ update_account_form.first_name.errors }}
                     </div>
                     <div class="col-sm-5">
-                        <p class="body-text">Last name</p>
-                        <input type="text">
+                        <label for="id_{{ form.last_name.html_name }}">{{ update_account_form.last_name.label }}</label>
+                        {{ update_account_form.last_name }}
+                        {{ update_account_form.last_name.errors }}
                     </div>
                 </div>
                 <div class="row row--under">
                     <div class="col-sm-6">
-                        <p class="body-text">Change email address (optional)</p>
-                        <input type="text">
+                        <label for="id_{{ form.email.html_name }}">{{ update_account_form.email.label }}</label>
+                        {{ update_account_form.email }}
+                        {{ update_account_form.email.errors }}
                     </div>
                     <div class="col-sm-6">
-                        <p class="body-text">New password (optional)</p>
-                        <input type="password">
+                        <label for="id_{{ form.password.html_name }}">{{ update_account_form.password.label }}</label>
+                        {{ update_account_form.password }}
+                        {{ update_account_form.password.errors }}
                     </div>
                 </div>
                 <div class="row row--under">
                     <div class="col-sm-6">
-                        <p class="body-text">Confirm new password</p>
-                        <input type="password">
+                        <label for="id_{{ form.confirm_password.html_name }}">{{ update_account_form.confirm_password.label }}</label>
+                        {{ update_account_form.confirm_password }}
+                        {{ update_account_form.confirm_password.errors }}
                     </div>
                     <div class="col-sm-6">
-                        <p class="body-text">Current password</p>
-                        <input type="password">
+                        <label for="id_{{ form.current_password.html_name }}">{{ update_account_form.current_password.label }}</label>
+                        {{ update_account_form.current_password }}
+                        {{ update_account_form.current_password.errors }}
                     </div>
                 </div>
+                <button id="update_button" type='submit' class='button--regular button--primary--negative' name="update_account">Update</button>
             </form>
-            <button class="button--regular button--primary--negative">Update my details</button>
         </div>
     </div>
 

--- a/portal/templates/redesign/teach_new/dashboard.html
+++ b/portal/templates/redesign/teach_new/dashboard.html
@@ -261,24 +261,24 @@
                     </div>
                 </div>
                 <div class="row row--under">
-                    <div class="col-sm-6">
+                    <div class="col-sm-12">
                         <label for="id_{{ form.email.html_name }}">{{ update_account_form.email.label }}</label>
                         {{ update_account_form.email }}
                         {{ update_account_form.email.errors }}
                     </div>
-                    <div class="col-sm-6">
+                </div>
+                <div class="row row--under">
+                    <div class="col-sm-4">
                         <label for="id_{{ form.password.html_name }}">{{ update_account_form.password.label }}</label>
                         {{ update_account_form.password }}
                         {{ update_account_form.password.errors }}
                     </div>
-                </div>
-                <div class="row row--under">
-                    <div class="col-sm-6">
+                    <div class="col-sm-4">
                         <label for="id_{{ form.confirm_password.html_name }}">{{ update_account_form.confirm_password.label }}</label>
                         {{ update_account_form.confirm_password }}
                         {{ update_account_form.confirm_password.errors }}
                     </div>
-                    <div class="col-sm-6">
+                    <div class="col-sm-4">
                         <label for="id_{{ form.current_password.html_name }}">{{ update_account_form.current_password.label }}</label>
                         {{ update_account_form.current_password }}
                         {{ update_account_form.current_password.errors }}

--- a/portal/templates/redesign/teach_new/dashboard.html
+++ b/portal/templates/redesign/teach_new/dashboard.html
@@ -135,7 +135,7 @@
         </div>
     </div>
 
-    <div class="background background--primary">
+    <div id="school-details" class="background background--primary">
         <div class="col-sm-7 col-center">
             <h3>Change details of your school or club</h3>
             <p class="body-text">Update your school or club&rsquo;s name and/or postcode.
@@ -198,7 +198,7 @@
         </div>
     </div>
 
-    <div class="background background--quaternary">
+    <div id="new-class" class="background background--quaternary">
         <div class="col-sm-7 col-center">
             <h3>Create a new class</h3>
             <p class="body-text">When you set up a new class, a unique class access code will automatically be generated, with you being identified as the teacher for that
@@ -333,5 +333,13 @@
         }
     });
 </script>
+
+{% if anchor %}
+    <script type="text/javascript">
+        $(document).ready(function(){
+            window.location = '#{{anchor}}'
+        });
+    </script>
+{% endif %}
 
 {% endblock content %}

--- a/portal/templates/redesign/teach_new/onboarding_classes.html
+++ b/portal/templates/redesign/teach_new/onboarding_classes.html
@@ -52,9 +52,9 @@
 
             <div class="section group">
 
-                <label for="id_{{ form.name.html_name }}">{{ form.name.label }}</label>
-                {{ form.name.errors }}
-                {{ form.name }}
+                <label for="id_{{ form.class_name.html_name }}">{{ form.class_name.label }}</label>
+                {{ form.class_name.errors }}
+                {{ form.class_name }}
                 <div class="col span_1_of_3">
                     <label for="id_{{ form.classmate_progress.html_name }}">{{ form.classmate_progress.label }}</label>
                     {{ form.classmate_progress.errors }}

--- a/portal/templates/redesign/teach_new/onboarding_print.html
+++ b/portal/templates/redesign/teach_new/onboarding_print.html
@@ -64,7 +64,7 @@
         <img title="Warning" alt="Warning sign" src='{% static "portal/img_new/warning.png" %}'>
         <p class="small-text"><i>This is the only time you will be able to view this page. You can print PDF format <br>reminder cards that populate these details which can
             be given to the students.</i></p>
-        <form target="_blank" method='post' action="{% url 'teacher_print_reminder_cards' class.access_code %}">
+        <form target="_blank" method='post' action="{% url 'teacher_print_reminder_cards_new' class.access_code %}">
             {% csrf_token %}
             <input type='hidden' name='data' value='{{ query_data }}'/>
             <div class='section'>
@@ -81,7 +81,7 @@
         <img src='{% static "portal/img_new/warning.png" %}'>
         <p class="small-text"><i>This is the only time you will be able to view this page. You can print PDF format <br>reminder cards that populate these details which can
             be given to the students.</i></p>
-        <form target="_blank" method='post' action="{% url 'teacher_print_reminder_cards' class.access_code %}">
+        <form target="_blank" method='post' action="{% url 'teacher_print_reminder_cards_new' class.access_code %}">
             {% csrf_token %}
             <input type='hidden' name='data' value='{{ query_data }}'/>
             <div class='section'>
@@ -113,7 +113,7 @@
             {% endfor %}
         </table>
         <section>
-            <form target="_blank" method='post' action="{% url 'teacher_print_reminder_cards' class.access_code %}">
+            <form target="_blank" method='post' action="{% url 'teacher_print_reminder_cards_new' class.access_code %}">
                 {% csrf_token %}
                 <input type='hidden' name='data' value='{{ query_data }}'/>
                 <div class='section'>

--- a/portal/tests/pageObjects/portal/teach/onboarding_classes_page.py
+++ b/portal/tests/pageObjects/portal/teach/onboarding_classes_page.py
@@ -49,7 +49,7 @@ class OnboardingClassesPage(TeachBasePage):
         assert self.on_correct_page('onboarding_classes_page')
 
     def create_class(self, name, classmate_progress):
-        self.browser.find_element_by_id('id_name').send_keys(name)
+        self.browser.find_element_by_id('id_class_name').send_keys(name)
         Select(self.browser.find_element_by_id('id_classmate_progress')).select_by_value(classmate_progress)
 
         self._click_create_class_button()

--- a/portal/tests/test_class_new.py
+++ b/portal/tests/test_class_new.py
@@ -38,7 +38,8 @@ from base_test_new import BaseTest
 
 from utils.teacher_new import signup_teacher_directly
 from utils.organisation_new import create_organisation_directly
-from utils.classes_new import create_class
+from utils.classes_new import create_class, create_class_directly
+from utils.student_new import create_school_student_directly
 from utils.messages import is_class_created_message_showing
 
 from django_selenium_clean import selenium
@@ -68,3 +69,17 @@ class TestClass(BaseTest):
             .create_class_empty()
 
         assert page.was_form_empty('form-create-class')
+
+    def test_create_dashboard(self):
+        email, password = signup_teacher_directly()
+        create_organisation_directly(email)
+        klass, name, access_code = create_class_directly(email)
+        create_school_student_directly(access_code)
+
+        page = self.go_to_homepage() \
+            .go_to_login_page() \
+            .login(email, password)
+
+        page, class_name = create_class(page)
+
+        assert is_class_created_message_showing(selenium, class_name)

--- a/portal/tests/test_organisation.py
+++ b/portal/tests/test_organisation.py
@@ -194,18 +194,18 @@ class TestOrganisation(BaseTest, BasePage):
 
         email, password = signup_teacher_directly()
 
-        page = self.go_to_homepage()\
-            .go_to_teach_page()\
-            .login(email, password)\
+        page = self.go_to_homepage() \
+            .go_to_teach_page() \
+            .login(email, password) \
             .go_to_organisation_create_or_join_page()
 
         page = page.join_organisation(names[n - 1])
         assert page.__class__.__name__ == 'TeachOrganisationRevokePage'
         assert page.check_organisation_name(names[n - 1], postcodes[n - 1])
 
-        page = page.logout()\
-            .go_to_teach_page()\
-            .login(emails[n - 1], passwords[n - 1])\
+        page = page.logout() \
+            .go_to_teach_page() \
+            .login(emails[n - 1], passwords[n - 1]) \
             .go_to_organisation_manage_page()
 
         assert page.has_join_request(email)
@@ -216,10 +216,10 @@ class TestOrganisation(BaseTest, BasePage):
         assert page.number_of_members() == 2
         assert page.number_of_admins() == 1
 
-        page = page\
-            .logout()\
-            .go_to_teach_page()\
-            .login(email, password)\
+        page = page \
+            .logout() \
+            .go_to_teach_page() \
+            .login(email, password) \
             .go_to_organisation_manage_page()
         assert page.check_organisation_name(names[n - 1])
         assert page.is_not_admin_view()

--- a/portal/tests/test_organisation_new.py
+++ b/portal/tests/test_organisation_new.py
@@ -40,9 +40,12 @@ from portal.tests.pageObjects.portal.base_page import BasePage
 from portal.tests.pageObjects.portal.home_page_new import HomePage
 from utils.teacher_new import signup_teacher_directly
 from utils.organisation_new import create_organisation, create_organisation_directly
+from utils.classes_new import create_class_directly
+from utils.student_new import create_school_student_directly
 from utils.messages import is_organisation_created_message_showing
 
 from django_selenium_clean import selenium
+import time
 
 
 class TestOrganisation(BaseTest, BasePage):
@@ -148,3 +151,31 @@ class TestOrganisation(BaseTest, BasePage):
         postcodes = ['' for i in range(n)]
 
         return emails, passwords, names, postcodes
+
+    def test_edit_details(self):
+        email, password = signup_teacher_directly()
+        school_name, postcode = create_organisation_directly(email)
+        _, class_name, access_code = create_class_directly(email)
+        student_name, password, student = create_school_student_directly(access_code)
+
+        selenium.get(self.live_server_url + "/portal/redesign/home")
+        page = HomePage(selenium) \
+            .go_to_login_page() \
+            .login(email, password)
+
+        assert page.check_organisation_details({
+            'name': school_name,
+            'postcode': postcode
+        })
+
+        new_name = 'new ' + school_name
+        new_postcode = 'OX2 6LE'
+
+        page.change_organisation_details({
+            'name': new_name,
+            'postcode': new_postcode
+        })
+        assert page.check_organisation_details({
+            'name': new_name,
+            'postcode': new_postcode
+        })

--- a/portal/tests/test_teacher_student_new.py
+++ b/portal/tests/test_teacher_student_new.py
@@ -57,6 +57,8 @@ class TestTeacherStudent(BaseTest):
         page, student_name = create_school_student(page)
         assert page.student_exists(student_name)
 
+        assert page.__class__.__name__ == 'OnboardingStudentListPage'
+
     def test_create_empty(self):
         email, password = signup_teacher_directly()
         org_name, postcode = create_organisation_directly(email)

--- a/portal/tests/test_views_new.py
+++ b/portal/tests/test_views_new.py
@@ -39,6 +39,7 @@ from django.core.urlresolvers import reverse
 from django.test import TestCase, Client
 from utils.teacher_new import signup_teacher_directly
 from utils.classes_new import create_class_directly
+from utils.student_new import create_school_student_directly
 
 
 class TestTeacherViews(TestCase):
@@ -46,6 +47,7 @@ class TestTeacherViews(TestCase):
     def setUpTestData(cls):
         cls.email, cls.password = signup_teacher_directly()
         _, _, cls.class_access_code = create_class_directly(cls.email)
+        create_school_student_directly(cls.class_access_code)
 
     def login(self):
         c = Client()
@@ -54,6 +56,6 @@ class TestTeacherViews(TestCase):
 
     def test_reminder_cards(self):
         c = self.login()
-        url = reverse('teacher_print_reminder_cards', args=[self.class_access_code])
+        url = reverse('teacher_print_reminder_cards_new', args=[self.class_access_code])
         response = c.get(url)
         self.assertEqual(response.status_code, 200)

--- a/portal/tests/utils/email.py
+++ b/portal/tests/utils/email.py
@@ -82,6 +82,12 @@ def follow_change_email_link_to_teach(page, email):
     return go_to_teach_page(page.browser)
 
 
+def follow_change_email_link_to_dashboard(page, email):
+    _follow_change_email_link(page, email)
+
+    return go_to_login_page(page.browser)
+
+
 def follow_change_email_link_to_play(page, email):
     _follow_change_email_link(page, email)
 

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -65,10 +65,10 @@ from portal.views.email import send_new_users_report
 
 from game.views.level import play_default_level
 
-from portal.views.email_new import verify_email_new
+from portal.views.email_new import verify_email_new, change_email
 from portal.views.home_new import login_view, logout_view_new, register_view
 from portal.views.organisation_new import organisation_fuzzy_lookup_new, organisation_manage_new
-from portal.views.teacher.teach_new import teacher_classes_new, teacher_class_new, teacher_class_students
+from portal.views.teacher.teach_new import teacher_classes_new, teacher_class_new, teacher_print_reminder_cards_new
 from portal.views.teacher.dashboard import dashboard_manage
 
 js_info_dict = {
@@ -205,11 +205,13 @@ urlpatterns = patterns(
     url(r'^redesign/login_form', login_view, name='login_new'),
     url(r'^redesign/logout/$', logout_view_new, name='logout_new'),
     url(r'^redesign/verify_email/(?P<token>[0-9a-f]+)/$', verify_email_new, name='verify_email_new'),
+    url(r'^redesign/change_email/(?P<token>[0-9a-f]+)/$', change_email, name='change_email'),
     url(r'^redesign/teach/$', TemplateView.as_view(template_name='redesign/teach_new.html'), name='teach_new'),
     url(r'^redesign/teach/fuzzy_lookup/$', organisation_fuzzy_lookup_new, name='organisation_fuzzy_lookup_new'),
     url(r'^redesign/teach/onboarding-organisation/$', organisation_manage_new, name='onboarding-organisation'),
     url(r'^redesign/teach/onboarding-classes', teacher_classes_new, name='onboarding-classes'),
-    url(r'^redesign/teach/onboarding-class/(?P<access_code>[A-Z0-9]+)', teacher_class_new, name='onboarding-class'),
+    url(r'^redesign/teach/onboarding-class/(?P<access_code>[A-Z0-9]+)/$', teacher_class_new, name='onboarding-class'),
+    url(r'^redesign/teach/onboarding-class/(?P<access_code>[A-Z0-9]+)/print_reminder_cards/$', teacher_print_reminder_cards_new, name='teacher_print_reminder_cards_new'),
     url(r'^redesign/teach/onboarding-complete', TemplateView.as_view(template_name='redesign/teach_new/onboarding_complete.html'), name='onboarding-complete'),
     url(r'^redesign/play', TemplateView.as_view(template_name='redesign/play_new.html'), name='play_new'),
     url(r'^redesign/about', TemplateView.as_view(template_name='redesign/about_new.html'), name='about_new'),

--- a/portal/views/teacher/dashboard.py
+++ b/portal/views/teacher/dashboard.py
@@ -87,16 +87,21 @@ def dashboard_teacher_view(request, is_admin):
     update_account_form.fields['first_name'].initial = request.user.first_name
     update_account_form.fields['last_name'].initial = request.user.last_name
 
+    anchor = ''
+
     if can_process_forms(request, is_admin):
         if 'update_school' in request.POST:
+            anchor = 'school-details'
             update_school_form = OrganisationForm(request.POST, user=request.user, current_school=school)
             process_update_school_form(request, school)
 
         elif 'create_class' in request.POST:
+            anchor = 'new-class'
             create_class_form = ClassCreationForm(request.POST)
             process_create_class_form(request, teacher)
 
         else:
+            anchor = 'account'
             update_account_form = TeacherEditAccountForm(request.user, request.POST)
             changing_email, new_email = process_update_account_form(request, teacher)
             if changing_email:
@@ -115,6 +120,7 @@ def dashboard_teacher_view(request, is_admin):
         'update_school_form': update_school_form,
         'create_class_form': create_class_form,
         'update_account_form': update_account_form,
+        'anchor': anchor,
     })
 
 

--- a/portal/views/teacher/dashboard.py
+++ b/portal/views/teacher/dashboard.py
@@ -79,7 +79,9 @@ def dashboard_teacher_view(request, is_admin):
     update_school_form.fields['name'].initial = school.name
     update_school_form.fields['postcode'].initial = school.postcode
     update_school_form.fields['country'].initial = school.country
+
     create_class_form = ClassCreationForm()
+
     update_account_form = TeacherEditAccountForm(request.user)
     update_account_form.fields['title'].initial = teacher.title
     update_account_form.fields['first_name'].initial = request.user.first_name

--- a/portal/views/teacher/teach.py
+++ b/portal/views/teacher/teach.py
@@ -152,7 +152,7 @@ def teacher_classes(request):
             created_class = create_class(form, teacher)
             messages.success(request, "The class '{className}' has been created successfully."
                              .format(className=created_class.name))
-        return HttpResponseRedirect(reverse_lazy('teacher_class', kwargs={'access_code': created_class.access_code}))
+            return HttpResponseRedirect(reverse_lazy('teacher_class', kwargs={'access_code': created_class.access_code}))
     else:
         form = ClassCreationForm(initial={'classmate_progress': 'False'})
 


### PR DESCRIPTION
The following forms now work on the new teacher dashboard page:
- Edit school details form
- Add a class form
- Edit account details form

Because those 3 forms are now on the same page (whereas before they were each on their own), the edit school details form and add a class form had clashing IDs (ie, the field for entering the school name and the field for entering the class name both had 'id_name' id.)
Therefore the create a class field has been renamed to 'id_class_name' which is why some modifications had to made on the forms.py file and some of the current views files.

Tests have been added for those forms as well.

**This PR doesn't require any others to be merged.**