### PR TITLE
Travis with Chromedriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
+sudo: required
+dist: trusty
 language: python
 python:
-  - 2.7
+  - 2.7.12
 env:
   global:
     secure: yhZstk2BCizpt3zidJp6+MFXK41/zl4ODA7YexGvVfdtyLkvyi1CSuCiDu+EcZn6QD1SGLcDBxRRB7F4ZTW+I9DHzDNDziawdGkVuUIQowUReklQ9W41sJJKzBO6HYpvp8Wvm8bkDfzwJtVpnKphckUoj8k+OXGmhoAl6/DVCsKiCSuZnJ1BxP2GA9cON2RGjJnKpiARXpLR5Zb+R73ALoi1YGU2o3Go8Z+2s7doibqiDlyzLK3nfHdjG5XgKAeYvn14udVyCtLQuaQe24xwDnc1dIOgkfkLdzjrLxoSNeFwhSowEQuWTyeBHBeDyCtJCLk762HW4qlbIacbl1bH6nLHHLznkTSvfUt9yK0tSpPxqUi4ooQxnMT4XFw+5Mg0e3soTgJKNWgG+1WXQ4+F4AC+l0IJdch0vVlH5WSuibvO1fUNzB5brSyrj0hXXtvEGvB31fXT54E6lhxymuAdLyAXHw4cCCc+UNrW3skn0vj3/J5jecbbwcF0DcOK4bjhJ+xHZJucwWtq6ioXGpj6S0u1Fe1dw3AJNNgyjwWTxaEzt3VQP7Znk0OxKGYyViEeEsF+TvVJyhuaaPGSisGc45I4U0/1bopUa5IrZh3EDpPJ8E1HDf++s2z/iVxqmBmbqU0SRtzhRh+ZIsbe+Lea9wx/Zw7k0AKnF1WQXbHacsY=
@@ -36,6 +38,10 @@ install:
   - pip install -e .
   - pip install coveralls
 before_script:
+  - wget http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip
+  - echo $PATH
+  - unzip chromedriver_linux64.zip -d /home/travis/virtualenv/python2.7.12/bin/
+  - export CHROME_BIN=chromium-browser
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
   - sleep 3

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,6 @@ install:
   - pip install coveralls
 before_script:
   - wget http://chromedriver.storage.googleapis.com/2.24/chromedriver_linux64.zip
-  - echo $PATH
   - unzip chromedriver_linux64.zip -d /home/travis/virtualenv/python2.7.12/bin/
   - export CHROME_BIN=chromium-browser
   - "export DISPLAY=:99.0"

--- a/portal/tests/base_test.py
+++ b/portal/tests/base_test.py
@@ -52,7 +52,7 @@ from portal.tests.pageObjects.portal.home_page import HomePage
 from deploy import captcha
 
 
-custom_handler.monkey_patch()
+custom_handler.add_timeout()
 
 
 @skipUnless(selenium, "Selenium is unconfigured")

--- a/portal/tests/base_test.py
+++ b/portal/tests/base_test.py
@@ -35,6 +35,8 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 import os
+import time
+import socket
 from django.core.urlresolvers import reverse
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -44,9 +46,14 @@ from unittest import skipUnless
 
 #### Uncomment to use FireFox
 # master_browser = webdriver.Firefox()
+from . import custom_handler
 from portal.tests.pageObjects.portal.game_page import GamePage
 from portal.tests.pageObjects.portal.home_page import HomePage
 from deploy import captcha
+
+
+custom_handler.monkey_patch()
+
 
 @skipUnless(selenium, "Selenium is unconfigured")
 class BaseTest(SeleniumTestCase):
@@ -86,4 +93,15 @@ class BaseTest(SeleniumTestCase):
         return GamePage(selenium)
 
     def _go_to_path(self, path):
-        selenium.get(self.live_server_url + path)
+        socket.setdefaulttimeout(20)
+        attempts = 0
+        while True:
+            try:
+                selenium.get(self.live_server_url + path)
+            except socket.timeout:
+                attempts += 1
+                if attempts > 2:
+                    raise
+                time.sleep(10)
+            else:
+                break

--- a/portal/tests/base_test.py
+++ b/portal/tests/base_test.py
@@ -95,7 +95,7 @@ class BaseTest(SeleniumTestCase):
     def _go_to_path(self, path):
         socket.setdefaulttimeout(20)
         attempts = 0
-        while True:
+        while attempts < 3:
             try:
                 selenium.get(self.live_server_url + path)
             except socket.timeout:
@@ -103,5 +103,5 @@ class BaseTest(SeleniumTestCase):
                 if attempts > 2:
                     raise
                 time.sleep(10)
-            else:
+            finally:
                 break

--- a/portal/tests/base_test_new.py
+++ b/portal/tests/base_test_new.py
@@ -35,6 +35,8 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 import os
+import socket
+import time
 from django.core.urlresolvers import reverse
 
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -87,4 +89,15 @@ class BaseTest(SeleniumTestCase):
         return GamePage(selenium)
 
     def _go_to_path(self, path):
-        selenium.get(self.live_server_url + path)
+        socket.setdefaulttimeout(20)
+        attempts = 0
+        while True:
+            try:
+                selenium.get(self.live_server_url + path)
+            except socket.timeout:
+                attempts += 1
+                if attempts > 2:
+                    raise
+                time.sleep(10)
+            else:
+                break

--- a/portal/tests/base_test_new.py
+++ b/portal/tests/base_test_new.py
@@ -91,7 +91,7 @@ class BaseTest(SeleniumTestCase):
     def _go_to_path(self, path):
         socket.setdefaulttimeout(20)
         attempts = 0
-        while True:
+        while attempts < 3:
             try:
                 selenium.get(self.live_server_url + path)
             except socket.timeout:
@@ -99,5 +99,5 @@ class BaseTest(SeleniumTestCase):
                 if attempts > 2:
                     raise
                 time.sleep(10)
-            else:
+            finally:
                 break

--- a/portal/tests/custom_handler.py
+++ b/portal/tests/custom_handler.py
@@ -53,5 +53,5 @@ class RequestHandler(testcases.QuietWSGIRequestHandler):
             return
 
 
-def monkey_patch():
+def add_timeout():
     testcases.QuietWSGIRequestHandler = RequestHandler

--- a/portal/tests/custom_handler.py
+++ b/portal/tests/custom_handler.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Code for Life
+#
+# Copyright (C) 2016, Ocado Innovation Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ADDITIONAL TERMS – Section 7 GNU General Public Licence
+#
+# This licence does not grant any right, title or interest in any “Ocado” logos,
+# trade names or the trademark “Ocado” or any other trademarks or domain names
+# owned by Ocado Innovation Limited or the Ocado group of companies or any other
+# distinctive brand features of “Ocado” as may be secured from time to time. You
+# must not distribute any modification of this program using the trademark
+# “Ocado” or claim any affiliation or association with Ocado or its employees.
+#
+# You are not authorised to use the name Ocado (or any of its trade names) or
+# the names of any author or contributor in advertising or for publicity purposes
+# pertaining to the distribution of this program, without the prior written
+# authorisation of Ocado.
+#
+# Any propagation, distribution or conveyance of this program must include this
+# copyright notice and these terms. You must not misrepresent the origins of this
+# program; modified versions of the program must be marked as such and not
+# identified as the original program.
+import socket
+
+from django.test import testcases
+
+
+class RequestHandler(testcases.QuietWSGIRequestHandler):
+
+    def handle(self):
+        try:
+            super(RequestHandler, self).handle()
+        except socket.timeout:
+            print('timed out')
+            self.requestline = ''
+            self.request_version = ''
+            self.command = ''
+            self.send_error(408)
+            return
+
+
+def monkey_patch():
+    testcases.QuietWSGIRequestHandler = RequestHandler

--- a/test_settings.py
+++ b/test_settings.py
@@ -3,12 +3,12 @@ from selenium import webdriver
 
 SELENIUM_WEBDRIVERS = {
     'default': {
-        'callable': webdriver.Firefox,
+        'callable': webdriver.Chrome,
         'args': (),
         'kwargs': {},
     },
-    'chrome': {
-        'callable': webdriver.Chrome,
+    'firefox': {
+        'callable': webdriver.Firefox,
         'args': (),
         'kwargs': {},
     },


### PR DESCRIPTION
Similarly to Rapid Router, makes Travis use Chrome/ChromeDriver for selenium testing instead of Firefox/Webdriver.

With Firefox, all the tests would be run in 14 minutes and 11 seconds.
With Chrome, all the tests now run in 8 minutes and 40 seconds, which is almost twice as quick!