### PR TITLE
Redesign 25 - Edit class page: delete students

### DIFF
--- a/portal/static/portal/js/teach_class.js
+++ b/portal/static/portal/js/teach_class.js
@@ -129,6 +129,21 @@ function deleteClassConfirmation(path) {
     openConfirmationBox('delete');
 }
 
+function deleteStudentsConfirmation(path) {
+    runIfStudentsSelected(function() {
+        CONFIRMATION_DATA.deleteStudents = {
+            options: {
+                title: 'Delete students'
+            },
+            html: '<p class="body-text">These students will be permanently deleted. Are you sure?</p>',
+            confirm: function () {
+                postSelectedStudents(path);
+            }
+        };
+        openConfirmationBox('deleteStudents');
+    })
+}
+
 function postSelectedStudents(path) {
     runIfStudentsSelected(function(selectedStudents) {
         post(path, {

--- a/portal/static/portal/sass/styles.scss
+++ b/portal/static/portal/sass/styles.scss
@@ -287,7 +287,6 @@ button {
 
 button,
 .button {
-  @include _padding(10px, 15px, 10px, 15px);
   border-radius: .8rem;
 }
 
@@ -314,6 +313,7 @@ button,
 .ui-dialog-buttonset button {
   @include _font-size(20px);
   @include _line-height(25px);
+  @include _padding(10px, 15px, 10px, 15px);
 }
 
 .button--small {
@@ -1211,7 +1211,6 @@ td {
 
   p {
     @include _padding(0px, 20px, 0px, 0px);
-    display: inline-block;
     vertical-align: middle;
   }
 
@@ -1318,6 +1317,42 @@ td {
 
 .student-status--online {
   background: $color-button-primary-action-positive;
+}
+
+.student-table {
+
+  a[class^='button'] {
+    padding: auto;
+  }
+
+  input {
+    @include _margin(0px, 5px, 0px, 0px);
+  }
+
+}
+
+.student-table__header {
+
+  * {
+    padding: 0;
+  }
+
+  .student-status {
+    @include _margin(0px, 5px, 0px, 0px);
+  }
+
+  .student-table__cell {
+    align-items: center;
+    display: flex;
+    justify-content: center;
+  }
+
+}
+
+.student-table__cell {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
 }
 
 .step {

--- a/portal/templates/redesign/teach_new/class_new.html
+++ b/portal/templates/redesign/teach_new/class_new.html
@@ -16,6 +16,19 @@
 <script type="text/javascript" src="{% static 'portal/js/teach_class.js' %}"></script>
 <script type="text/javascript" src="{% static 'portal/js/common.js' %}"></script>
 <script type="text/javascript" src="{% static 'portal/js/lib/jquery-ui.js' %}"></script>
+<script>
+    var DELETE_STUDENTS_URL = "{% url 'teacher_delete_students_new' class.access_code %}";
+
+    var CONFIRMATION_DATA = {
+        'deleteStudents': {
+            options: {
+                title: 'Delete students'
+            },
+            html: '<p>These students will be permanently deleted. Are you sure?</p>',
+            confirm: function() { postSelectedStudents(DELETE_STUDENTS_URL); }
+        }
+    };
+</script>
 {% endblock scripts %}
 
 {% block pageID %}id='homeWrapper'{% endblock %}
@@ -58,7 +71,7 @@
                     <th class="cell-center">
                         <p class="body-text">Select</p>
                         <div class="row--flex">
-                            <input type="checkbox" name="vehicle" value="">
+                            <input id='selectedStudentsListToggle' name='selectedStudentsListToggle' type="checkbox" value="">
                             <p class="small-text">Select all</p>
                         </div>
                     </th>
@@ -71,7 +84,7 @@
                 </tr>
                 {% for student in students %}
                 <tr>
-                    <td class="cell-center"><input type="checkbox" name="vehicle" value=""></td>
+                    <td class="cell-center"><input id="student_checkbox" type="checkbox" class='student' name='{{ student.id }}' value=""></td>
                     <td>
                         <p class="small-text">{{ student.new_user.first_name }}</p>
                         <a id="edit_student_button" href="{% url 'teacher_edit_student_new' student.id %}" class="button button--small button--primary--positive">Edit</a>
@@ -84,10 +97,10 @@
                 {% endfor %}
                 <tr>
                     <td class="table-footer" colspan="3" rowspan="2">
-                        <p class="small-text">0/7 selected</p>
+                        <p class="small-text"><span id="num_students_selected">0</span>/{{ num_students }} selected</p>
                         <button class="button--small button--primary--navigation">Move</button>
                         <button class="button--small button--primary--navigation">Release</button>
-                        <button class="button--small button--primary--danger">Delete</button>
+                        <button id="deleteSelectedStudents" class="button--small button--primary--danger">Delete</button>
                         <button class="button--small button--primary--danger">Reset passwords</button>
                     </td>
                 </tr>

--- a/portal/templates/redesign/teach_new/class_new.html
+++ b/portal/templates/redesign/teach_new/class_new.html
@@ -16,19 +16,6 @@
 <script type="text/javascript" src="{% static 'portal/js/teach_class.js' %}"></script>
 <script type="text/javascript" src="{% static 'portal/js/common.js' %}"></script>
 <script type="text/javascript" src="{% static 'portal/js/lib/jquery-ui.js' %}"></script>
-<script>
-    var DELETE_STUDENTS_URL = "{% url 'teacher_delete_students_new' class.access_code %}";
-
-    var CONFIRMATION_DATA = {
-        'deleteStudents': {
-            options: {
-                title: 'Delete students'
-            },
-            html: '<p>These students will be permanently deleted. Are you sure?</p>',
-            confirm: function() { postSelectedStudents(DELETE_STUDENTS_URL); }
-        }
-    };
-</script>
 {% endblock scripts %}
 
 {% block pageID %}id='homeWrapper'{% endblock %}
@@ -66,11 +53,11 @@
                 make them an independent Code for Life user, or delete them permanently.</p>
         </div>
         <div class="col-sm-6">
-            <table id="student_table" class="header-secondary data-quaternary">
-                <tr>
+            <table id="student_table" class="student-table header-secondary data-quaternary">
+                <tr class="student-table__header">
                     <th class="cell-center">
                         <p class="body-text">Select</p>
-                        <div class="row--flex">
+                        <div class="student-table__cell">
                             <input id='selectedStudentsListToggle' name='selectedStudentsListToggle' type="checkbox" value="">
                             <p class="small-text">Select all</p>
                         </div>
@@ -78,16 +65,18 @@
                     <th><p class="body-text">Student details</p></th>
                     <th>
                         <p class="body-text">Status</p>
-                        <div class="row--flex"><div class="student-status student-status--online"></div><p class="small-text">Logged in</p></div>
-                        <div class="row--flex"><div class="student-status student-status--offline"></div><p class="small-text">Logged out</p></div>
+                        <div class="student-table__cell"><div class="student-status student-status--online"></div><p class="small-text">Logged in</p></div>
+                        <div class="student-table__cell"><div class="student-status student-status--offline"></div><p class="small-text">Logged out</p></div>
                     </th>
                 </tr>
                 {% for student in students %}
                 <tr>
                     <td class="cell-center"><input id="student_checkbox" type="checkbox" class='student' name='{{ student.id }}' value=""></td>
                     <td>
-                        <p class="small-text">{{ student.new_user.first_name }}</p>
-                        <a id="edit_student_button" href="{% url 'teacher_edit_student_new' student.id %}" class="button button--small button--primary--positive">Edit</a>
+                        <div class="student-table__cell">
+                            <p class="small-text">{{ student.new_user.first_name }}</p>
+                            <a id="edit_student_button" href="{% url 'teacher_edit_student_new' student.id %}" class="button button--small button--primary--positive">Edit</a>
+                        </div>
                     </td>
                     <td>
                         {% if student.logged_in %}<div class="student-status student-status--online"></div>
@@ -100,7 +89,8 @@
                         <p class="small-text"><span id="num_students_selected">0</span>/{{ num_students }} selected</p>
                         <button class="button--small button--primary--navigation">Move</button>
                         <button class="button--small button--primary--navigation">Release</button>
-                        <button id="deleteSelectedStudents" class="button--small button--primary--danger">Delete</button>
+                        <button onclick="deleteStudentsConfirmation('{% url 'teacher_delete_students_new' class.access_code %}')"
+                                id="deleteSelectedStudents" class="button--small button--primary--danger">Delete</button>
                         <button class="button--small button--primary--danger">Reset passwords</button>
                     </td>
                 </tr>

--- a/portal/tests/pageObjects/portal/teach/class_page_new.py
+++ b/portal/tests/pageObjects/portal/teach/class_page_new.py
@@ -66,27 +66,40 @@ class TeachClassPage(TeachBasePage):
         self.browser.find_element_by_id('deleteClass').click()
         return self
 
+    def delete_students(self):
+        self.browser.find_element_by_id('deleteSelectedStudents').click()
+        return self
+
     def cancel_dialog(self):
         self.browser.find_element_by_xpath(
             "//div[contains(@class,'ui-dialog')]//span[contains(text(),'Cancel')]").click()
         return self
 
-    def confirm_dialog(self):
+    def confirm_delete_class_dialog(self):
         self._click_confirm()
 
         return dashboard_page_new.TeachDashboardPage(self.browser)
 
-    def is_dialog_showing(self):
-        return self.browser.find_element_by_xpath("//div[contains(@class,'ui-dialog')]").is_displayed()
+    def confirm_delete_student_dialog(self):
+        self._click_confirm()
+
+        return self
 
     def confirm_dialog_expect_error(self):
         self._click_confirm()
 
         return self
 
+    def is_dialog_showing(self):
+        return self.browser.find_element_by_xpath("//div[contains(@class,'ui-dialog')]").is_displayed()
+
     def _click_confirm(self):
         self.browser.find_element_by_xpath(
             "//div[contains(@class,'ui-dialog')]//span[contains(text(),'Confirm')]").click()
+
+    def toggle_select_student(self):
+        self.browser.find_element_by_id("student_checkbox").click()
+        return self
 
     def wait_for_messages(self):
         self.wait_for_element_by_id('messages')

--- a/portal/tests/test_class_new.py
+++ b/portal/tests/test_class_new.py
@@ -84,6 +84,23 @@ class TestClass(BaseTest):
 
         assert is_class_created_message_showing(selenium, class_name)
 
+    def test_delete_empty(self):
+        email, password = signup_teacher_directly()
+        create_organisation_directly(email)
+        _, class_name, access_code = create_class_directly(email)
+        create_school_student_directly(access_code)
+
+        page = self.go_to_homepage().go_to_login_page().login(email, password)
+        page = page.go_to_class_page()
+
+        page = page.toggle_select_student().delete_students()
+        page = page.confirm_delete_student_dialog()
+        page = page.delete_class()
+        assert page.is_dialog_showing()
+        page = page.confirm_delete_class_dialog()
+        assert page.__class__.__name__ == 'TeachDashboardPage'
+        assert page.does_not_have_classes()
+
     def test_delete_nonempty(self):
         email, password = signup_teacher_directly()
         create_organisation_directly(email)

--- a/portal/tests/test_teacher_student_new.py
+++ b/portal/tests/test_teacher_student_new.py
@@ -162,3 +162,20 @@ class TestTeacherStudent(BaseTest):
         page = page.click_generate_password_button()
 
         assert page.__class__.__name__ == 'EditStudentPasswordPage'
+
+    def test_delete(self):
+        email, password = signup_teacher_directly()
+        create_organisation_directly(email)
+        _, class_name, access_code = create_class_directly(email)
+        student_name, student_password, _ = create_school_student_directly(access_code)
+
+        selenium.get(self.live_server_url + "/portal/redesign/home")
+        page = HomePage(selenium).go_to_login_page().login(email, password)
+        page = page.go_to_class_page()
+        assert page.student_exists(student_name)
+
+        page = page.toggle_select_student().delete_students()
+        assert page.is_dialog_showing()
+        page = page.confirm_delete_student_dialog()
+
+        assert not page.student_exists(student_name)

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -71,7 +71,7 @@ from portal.views.home_new import login_view, logout_view_new, register_view
 from portal.views.organisation_new import organisation_fuzzy_lookup_new, organisation_manage_new
 from portal.views.teacher.teach_new import teacher_classes_new, teacher_class_new, teacher_view_class, \
     teacher_delete_class_new, teacher_edit_class_new, teacher_move_class_new, teacher_edit_student_new, \
-    teacher_student_reset_new, materials_viewer_new, teacher_print_reminder_cards_new
+    teacher_student_reset_new, materials_viewer_new, teacher_print_reminder_cards_new, teacher_delete_students_new
 from portal.views.teacher.dashboard import dashboard_manage, organisation_allow_join_new, organisation_deny_join_new, \
     organisation_kick_new, organisation_toggle_admin_new, teacher_disable_2FA_new
 
@@ -231,6 +231,7 @@ urlpatterns = patterns(
     url(r'^redesign/teach/dashboard/deny_join/(?P<pk>[0-9]+)/$', organisation_deny_join_new, name='organisation_deny_join_new'),
     url(r'^redesign/teach/class/(?P<access_code>[A-Z0-9]+)/$', teacher_view_class, name='view_class'),
     url(r'^redesign/teach/class/delete/(?P<access_code>[A-Z0-9]+)/$', teacher_delete_class_new, name='teacher_delete_class_new'),
+    url(r'^redesign/teach/class/(?P<access_code>[A-Z0-9]+)/students/delete/$', teacher_delete_students_new, name='teacher_delete_students_new'),
     url(r'^redesign/teach/class/edit/(?P<access_code>[A-Z0-9]+)/$', teacher_edit_class_new, name='teacher_edit_class_new'),
     url(r'^redesign/teach/class/student/edit/(?P<pk>[0-9]+)/$', teacher_edit_student_new, name='teacher_edit_student_new'),
     url(r'^redesign/teach/class/student/reset/(?P<pk>[0-9]+)/$', teacher_student_reset_new, name='teacher_student_reset_new'),

--- a/portal/views/teacher/teach_new.py
+++ b/portal/views/teacher/teach_new.py
@@ -270,6 +270,26 @@ def teacher_delete_class_new(request, access_code):
 
 @login_required(login_url=reverse_lazy('login_new'))
 @user_passes_test(logged_in_as_teacher, login_url=reverse_lazy('login_new'))
+def teacher_delete_students_new(request, access_code):
+    klass = get_object_or_404(Class, access_code=access_code)
+
+    # check user is authorised to deal with class
+    if request.user.new_teacher != klass.teacher:
+        raise Http404
+
+    # get student objects for students to be deleted, confirming they are in the class
+    student_ids = json.loads(request.POST.get('transfer_students', '[]'))
+    students = [get_object_or_404(Student, id=i, class_field=klass) for i in student_ids]
+
+    # Delete all of the students
+    for student in students:
+        student.new_user.delete()
+
+    return HttpResponseRedirect(reverse_lazy('view_class', kwargs={'access_code': access_code}))
+
+
+@login_required(login_url=reverse_lazy('login_new'))
+@user_passes_test(logged_in_as_teacher, login_url=reverse_lazy('login_new'))
 def teacher_edit_class_new(request, access_code):
     klass = get_object_or_404(Class, access_code=access_code)
 

--- a/portal/views/teacher/teach_new.py
+++ b/portal/views/teacher/teach_new.py
@@ -35,7 +35,7 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 import json
-
+from functools import partial, wraps
 from datetime import timedelta
 
 from django.conf import settings
@@ -45,6 +45,7 @@ from django.core.urlresolvers import reverse_lazy
 from django.contrib import messages as messages
 from django.contrib.auth.decorators import login_required, user_passes_test
 from django.contrib.staticfiles.storage import staticfiles_storage
+from django.forms.formsets import formset_factory
 from django.utils import timezone
 
 from reportlab.pdfgen import canvas
@@ -54,9 +55,9 @@ from reportlab.lib.utils import ImageReader
 from reportlab.platypus import Paragraph
 from reportlab.lib.styles import ParagraphStyle
 
-from portal.models import Class, Student, Teacher
-from portal.forms.teach_new import ClassCreationForm, StudentCreationForm, ClassMoveForm, ClassEditForm, \
-    TeacherEditStudentForm, TeacherSetStudentPass
+from portal.models import Teacher, Class, Student
+from portal.forms.teach_new import TeacherEditAccountForm, ClassCreationForm, ClassEditForm, ClassMoveForm, \
+    TeacherEditStudentForm, TeacherSetStudentPass, StudentCreationForm
 from portal.permissions import logged_in_as_teacher
 from portal.helpers.generators import generate_access_code, generate_password
 from portal.views.teacher.pdfs import PDF_DATA


### PR DESCRIPTION
Functionality for deleting students from classes added.

**This PR contains mostly Python changes. The few CSS and HTML changes have been done to fix the CSS issues of the student list table in the edit class page - no new page has been created.**