### PR TITLE
Updates for edit class page

### DIFF
--- a/portal/templates/redesign/teach_new/class_new.html
+++ b/portal/templates/redesign/teach_new/class_new.html
@@ -39,9 +39,9 @@
 
 <section class="background">
     <h2>{{ user|make_into_username }}, {{ class.name }} ({{ class.access_code }})</h2>
-    <h4 class="col-sm-6 col-center">Here you can view and manage all of your students within each of your classes. We&rsquo;ve created reminder cards which includes each
-        students login details for you to print out, meaning they won&rsquo;t forget and you don&rsquo;t have to remember this for them. You can add new students, transfer
+    <h4 class="col-sm-6 col-center">Here you can view and manage all of your students within this class. You can add new students, transfer
         existing students to another one of your classes or to another teacher within your school or club, or remove students altogether.</h4>
+    <a href="#add_new_students" class="button button--regular button--secondary button--secondary--dark">Add students</a>
 </section>
 
 <div class="background col-sm-8 col-center">
@@ -101,7 +101,7 @@
     <p class="body-text"><a href="{% url 'dashboard' %}#classes">&#10229; Back to Classes</a></p>
 </div>
 
-<div class="background background--quaternary">
+<div id="add_new_students" class="background background--quaternary">
     <div class="col-sm-8 col-center">
         <div class="row">
             <div class="col-sm-6">

--- a/portal/views/teacher/dashboard.py
+++ b/portal/views/teacher/dashboard.py
@@ -100,7 +100,10 @@ def dashboard_teacher_view(request, is_admin):
         elif 'create_class' in request.POST:
             anchor = 'new-class'
             create_class_form = ClassCreationForm(request.POST)
-            process_create_class_form(request, teacher)
+            if create_class_form.is_valid():
+                created_class = create_class_new(create_class_form, teacher)
+                messages.success(request, "The class '{className}' has been created successfully.".format(className=created_class.name))
+                return HttpResponseRedirect(reverse_lazy('view_class', kwargs={'access_code': created_class.access_code}))
 
         else:
             anchor = 'account'
@@ -149,13 +152,6 @@ def process_update_school_form(request, school):
         school.save()
 
         messages.success(request, 'You have updated the details for your school or club successfully.')
-
-
-def process_create_class_form(request, teacher):
-    create_class_form = ClassCreationForm(request.POST)
-    if create_class_form.is_valid():
-        created_class = create_class_new(create_class_form, teacher)
-        messages.success(request, "The class '{className}' has been created successfully.".format(className=created_class.name))
 
 
 def create_class_new(form, teacher):


### PR DESCRIPTION
Following issue #445 and @j4mesholland 's new wireframe:
- the user is redirected to the new class page upon creating a new class from the dashboard
- the introduction text on the page has been shortened
- there is now a button to prompt the user to add new students to the new class