### PR TITLE
Allow changing the class_name in tests when creating a class

### DIFF
--- a/portal/tests/utils/classes.py
+++ b/portal/tests/utils/classes.py
@@ -55,8 +55,11 @@ def generate_email(name):
     return name.replace(' ', '_') + '@codeforlife.com'
 
 
-def create_class_directly(teacher_email):
+def create_class_directly(teacher_email, class_name=None):
     name, accesss_code = generate_details()
+
+    if class_name is not None:
+        name = class_name
 
     teacher = Teacher.objects.get(new_user__email=teacher_email)
 

--- a/portal/tests/utils/classes_new.py
+++ b/portal/tests/utils/classes_new.py
@@ -51,8 +51,11 @@ def generate_details():
 generate_details.next_id = 1
 
 
-def create_class_directly(teacher_email):
+def create_class_directly(teacher_email, class_name=None):
     name, accesss_code = generate_details()
+
+    if class_name is not None:
+        name = class_name
 
     teacher = Teacher.objects.get(new_user__email=teacher_email)
 


### PR DESCRIPTION
I would like to set class name in test to some string containing accent in order to fix ocadotechnology/rapid-router#891