### PR TITLE
Updated reset password email with no apostrophe

### DIFF
--- a/portal/templates/redesign/reset_password_email.html
+++ b/portal/templates/redesign/reset_password_email.html
@@ -1,5 +1,5 @@
 {% autoescape off %}
-You&rsquo;re receiving this e-mail because you requested a password reset for your Code For Life user account.
+You are receiving this e-mail because you requested a password reset for your Code For Life user account.
 
 Please go to the following page and choose a new password:
 {% block reset_link %}

--- a/portal/templates/registration/password_reset_email.html
+++ b/portal/templates/registration/password_reset_email.html
@@ -1,5 +1,5 @@
 {% autoescape off %}
-You're receiving this e-mail because you requested a password reset for your Code For Life user account.
+You are receiving this e-mail because you requested a password reset for your Code For Life user account.
 
 Please go to the following page and choose a new password:
 {% block reset_link %}


### PR DESCRIPTION
Details of issue: #465 

The message has been rewritten: 'You're' has been replaced with 'You are' so there is no more need for the apostrophe.