### PR TITLE
Redesign: 2FA login redirect

### DIFF
--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -61,6 +61,8 @@ ROOT_URLCONF = 'django_autoconfig.autourlconf'
 
 WSGI_APPLICATION = 'example_project.wsgi.application'
 
+LOGIN_REDIRECT_URL = '/portal/redesign/teach/dashboard/'
+
 INSTALLED_APPS = (
     'portal',
 )

--- a/portal/templates/redesign/teach_new/dashboard.html
+++ b/portal/templates/redesign/teach_new/dashboard.html
@@ -333,17 +333,26 @@
                         You have {{ backup_tokens }} backup tokens remaining.
                         {% endif %}</p>
                     <p class="body-text">View and create backup tokens for your account.</p>
-                    <button class="button--regular button--primary--negative">Manage backup tokens</button>
+                    <div class="background">
+                        <a class="button button--regular button--primary--negative"
+                           href="{% url 'two_factor:backup_tokens' %}">Manage backup tokens</a>
+                    </div>
                 </div>
                 <div class="col-sm-6 col-sm-offset-1">
                     <h4>Disable Two Factor Authentication</h4>
                     <p class="body-text">We recommend you to continue using Two Factor Authentication, however you can disable two factor authentication for your account.</p>
-                    <button class="button--regular button--secondary button--secondary--dark">Disable Two-Factor Authentication</button>
+                    <div class="background">
+                        <a class="button button--regular button--secondary button--secondary--dark"
+                           href="{% url 'two_factor:disable' %}">Disable Two-Factor Authentication</a>
+                    </div>
                 </div>
             </div>
         {% else %}
             <p class="body-text">Find out more about Two Factor Authentication and how it helps keep your account secure.</p>
-            <button class='button--regular button--primary--negative'>Setup Two Factor Authentication</button>
+            <div class="background">
+                <a class='button button--regular button--primary--negative'
+                   href="{% url 'two_factor:profile' %}">Setup Two Factor Authentication</a>
+            </div>
         {% endif %}
     </div>
 </div>

--- a/portal/templates/two_factor/core/setup_complete.html
+++ b/portal/templates/two_factor/core/setup_complete.html
@@ -10,6 +10,5 @@
 <p>{% blocktrans %}Congratulations, you've successfully enabled two-factor
     authentication.{% endblocktrans %}
 
-<p><a href="{% url 'teach' %}"
-      class="btn btn-block btn-default">{% trans "OK" %}</a></p>
+<p><a href="{% url 'dashboard' %}" class="btn btn-block btn-default">{% trans "OK" %}</a></p>
 {% endblock %}

--- a/portal/views/teacher/home_new.py
+++ b/portal/views/teacher/home_new.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Code for Life
 #
-# Copyright (C) 2016, Ocado Innovation Limited
+# Copyright (C) 2017, Ocado Innovation Limited
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as

--- a/portal/views/teacher/home_new.py
+++ b/portal/views/teacher/home_new.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# Code for Life
+#
+# Copyright (C) 2016, Ocado Innovation Limited
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# ADDITIONAL TERMS – Section 7 GNU General Public Licence
+#
+# This licence does not grant any right, title or interest in any “Ocado” logos,
+# trade names or the trademark “Ocado” or any other trademarks or domain names
+# owned by Ocado Innovation Limited or the Ocado group of companies or any other
+# distinctive brand features of “Ocado” as may be secured from time to time. You
+# must not distribute any modification of this program using the trademark
+# “Ocado” or claim any affiliation or association with Ocado or its employees.
+#
+# You are not authorised to use the name Ocado (or any of its trade names) or
+# the names of any author or contributor in advertising or for publicity purposes
+# pertaining to the distribution of this program, without the prior written
+# authorisation of Ocado.
+#
+# Any propagation, distribution or conveyance of this program must include this
+# copyright notice and these terms. You must not misrepresent the origins of this
+# program; modified versions of the program must be marked as such and not
+# identified as the original program.
+from django.core.urlresolvers import reverse, reverse_lazy
+from django.contrib import messages as messages
+from django.contrib.auth.decorators import login_required, user_passes_test
+from django.http import HttpResponseRedirect
+from portal.utils import using_two_factor
+
+from portal.models import Teacher, Student
+from portal.permissions import logged_in_as_teacher
+
+
+@login_required(login_url=reverse_lazy('login_new'))
+@user_passes_test(logged_in_as_teacher, login_url=reverse_lazy('login_new'))
+def teacher_home(request):
+    teacher = request.user.new_teacher
+
+    pending_student_request_warning(request, teacher)
+
+    pending_teacher_request_warning(request, teacher)
+
+    two_form_authentication_warnings(request, teacher)
+
+    return HttpResponseRedirect(reverse_lazy('dashboard'))
+
+
+def pending_student_request_warning(request, teacher):
+    if Student.objects.filter(pending_class_request__teacher=teacher).exists():
+        messages.info(request,
+                      'You have pending requests from students wanting to join your classes. '
+                      '<a href="#classes">Review these requests.</a>', extra_tags='safe')
+
+
+def pending_teacher_request_warning(request, teacher):
+    if teacher.is_admin and Teacher.objects.filter(pending_join_request=teacher.school).exists():
+        messages.info(request,
+                      'You have pending requests from teachers wanting to join your school or club. '
+                      '<a href="#requests">Review these requests.</a>', extra_tags='safe')
+
+
+def two_form_authentication_warnings(request, teacher):
+    # For teachers using 2FA, warn if they don't have backup tokens set, and warn solo-admins to set up another admin
+    if using_two_factor(request.user):
+
+        backup_tokens = check_backup_tokens(request)
+        if not backup_tokens > 0:
+            link = reverse('two_factor:profile')
+            messages.warning(request,
+                             'You do not have any backup tokens set up for two factor authentication, so could lose '
+                             'access to your account if you have problems with your smartphone or tablet. '
+                             '<a href="{link}">Set up backup tokens now</a>.'.format(link=link), extra_tags='safe')
+        # check admin
+        if teacher.is_admin:
+            admins = Teacher.objects.filter(school=teacher.school, is_admin=True)
+            if len(admins) == 1:
+                messages.warning(request,
+                                 'You are the only administrator in your school and are using Two Factor '
+                                 'Authentication (2FA). We recommend you <a href="#school">set up another '
+                                 'administrator</a> who will be able to disable your 2FA should you have problems with '
+                                 'your smartphone or tablet.', extra_tags='safe')
+
+
+def check_backup_tokens(request):
+    try:
+        backup_tokens = request.user.staticdevice_set.all()[0].token_set.count()
+    except Exception:
+        backup_tokens = 0
+
+    return backup_tokens


### PR DESCRIPTION
After login in with 2FA, the teachers are redirected to the new redesigned pages.
Other 2FA functionality (such as managing backup tokens, disabling 2FA...) still uses the old pages but still redirects to the new pages once the task is done.

**Please note that this won't work straight away - after this is merged it will require the merge of the PR on the appengine**