### PR TITLE
PDF viewer page: correct video download URL

### DIFF
--- a/portal/static/portal/sass/partials/_banners.scss
+++ b/portal/static/portal/sass/partials/_banners.scss
@@ -170,8 +170,11 @@
 
 .banner--resources {
   @include _padding(0px, 0px, 30px, 0px);
+  align-items: center;
   background-image: url('../img/background_blue.png');
   background-position: top right;
+  display: flex;
+  justify-content: space-between;
 }
 
 @media (max-width: 1200px) {

--- a/portal/templates/portal/teach/viewer.html
+++ b/portal/templates/portal/teach/viewer.html
@@ -37,7 +37,7 @@
         <div class="resource-buttons">
             <a href="{{ url }}" download class="button button--regular button--primary--general-educate">Download PDF</a>
             {% if video_link %}
-            <a href="{{ url }}" download class="button button--regular button--primary--negative">Download Video</a>
+            <a href="{{ video_download_link }}" download class="button button--regular button--primary--negative">Download Video</a>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
- The link to download the video was actually the one to download the PDF, now fixed.
- The banner now uses Flexbox.