### PR TITLE
Anchors fix: text stays after anchor has been visited

### DIFF
--- a/portal/static/portal/sass/partials/_buttons.scss
+++ b/portal/static/portal/sass/partials/_buttons.scss
@@ -7,7 +7,6 @@ a {
 a,
 a:hover,
 a:active,
-a:visited,
 a:focus {
   color: $color-text-tertiary;
 }
@@ -25,7 +24,6 @@ button,
 .button,
 .button:hover,
 .button:active,
-.button:visited,
 .button:focus {
   color: $color-text-secondary;
   text-decoration: none;
@@ -218,7 +216,6 @@ button,
 
   &:hover,
   &:active,
-  &:visited,
   &:focus{
     background-color: $color-background-tertiary;
     color: $color-text-secondary;

--- a/portal/static/portal/sass/partials/_subnavs.scss
+++ b/portal/static/portal/sass/partials/_subnavs.scss
@@ -3,8 +3,7 @@
 .sub-nav--warning {
   p,
   a,
-  a:hover,
-  a:visited {
+  a:hover {
     color: $color-text-primary;
   }
 }
@@ -73,8 +72,7 @@
 
   a:focus,
   a:hover,
-  a:active,
-  a:visited {
+  a:active {
     background-color: $color-background-secondary;
     color: $color-teacher-blue;
   }


### PR DESCRIPTION
Because of some CSS rules using the 'visited' anchor attribute, the text of the anchor would disappear after the user had clicked on the anchor. Now fixed!