### PR TITLE
Registration: users get an email if they try to reregister

### DIFF
--- a/portal/emailMessages.py
+++ b/portal/emailMessages.py
@@ -50,7 +50,7 @@ def emailVerificationNeededEmail(request, token):
         'subject': emailSubjectPrefix() + " : Email address verification needed",
         'message': ("Please go to " +
                     request.build_absolute_uri(reverse('verify_email', kwargs={'token': token})) +
-                    " to verify your email address" + emailBodySignOff(request)),
+                    " to verify your email address." + emailBodySignOff(request)),
     }
 
 
@@ -70,6 +70,17 @@ def emailChangeNotificationEmail(request, new_email):
         'message': ("Someone has tried to change the email address of your account. If this was " +
                     "not you, please get in contact with us via " +
                     request.build_absolute_uri(reverse('help')) + "#contact ." +
+                    emailBodySignOff(request)),
+    }
+
+
+def userAlreadyRegisteredEmail(request, email):
+    return {
+        'subject': emailSubjectPrefix() + " : Duplicate account error",
+        'message': ("A user is already registered with this email address: " +
+                    email + ".\nIf you've already registered, please login: " +
+                    request.build_absolute_uri(reverse('login_view')) + ".\n" +
+                    "Otherwise please register with a different email address." +
                     emailBodySignOff(request)),
     }
 

--- a/portal/forms/teach.py
+++ b/portal/forms/teach.py
@@ -107,7 +107,7 @@ class TeacherSignupForm(forms.Form):
 
         if password and not password_strength_test(password):
             raise forms.ValidationError(
-                "Password not strong enough, consider using at least 8 characters, upper and lower " + "case letters, and numbers")
+                "Password not strong enough, consider using at least 8 characters, upper and lower case letters, and numbers")
 
         return password
 

--- a/portal/tests/test_teacher.py
+++ b/portal/tests/test_teacher.py
@@ -43,11 +43,12 @@ from django.core import mail
 
 from base_test import BaseTest
 from pageObjects.portal.home_page import HomePage
-from utils.teacher import signup_teacher, signup_teacher_directly
+from utils.teacher import signup_teacher, signup_teacher_directly, signup_duplicate_teacher_fail
 from utils.organisation import create_organisation_directly
 from utils.classes import create_class_directly
 from utils.student import create_school_student_directly
-from utils.messages import is_email_verified_message_showing, is_teacher_details_updated_message_showing, is_teacher_email_updated_message_showing
+from utils.messages import is_email_verified_message_showing, is_teacher_details_updated_message_showing, \
+    is_teacher_email_updated_message_showing
 from utils import email as email_utils
 
 
@@ -58,6 +59,17 @@ class TestTeacher(BaseTest):
         page = HomePage(selenium)
         page, _, _ = signup_teacher(page)
         assert is_email_verified_message_showing(selenium)
+
+    def test_signup_duplicate_failure(self):
+        selenium.get(self.live_server_url)
+        page = HomePage(selenium)
+        page, email, _ = signup_teacher(page)
+        assert is_email_verified_message_showing(selenium)
+
+        selenium.get(self.live_server_url)
+        page = HomePage(selenium)
+        page, _, _ = signup_duplicate_teacher_fail(page, email)
+        assert page.__class__.__name__ == 'LoginPage'
 
     def test_login_failure(self):
         selenium.get(self.live_server_url)

--- a/portal/tests/utils/email.py
+++ b/portal/tests/utils/email.py
@@ -50,9 +50,24 @@ def follow_verify_email_link_to_login(page, email):
     return go_to_login_page(page.browser)
 
 
+def follow_duplicate_account_link_to_login(page, email):
+    _follow_duplicate_account_email_link(page, email)
+
+    return go_to_login_page(page.browser)
+
+
 def _follow_verify_email_link(page, email):
     message = str(email.message())
     prefix = '<p>Please go to <a href="'
+    i = string.find(message, prefix) + len(prefix)
+    suffix = '" rel="nofollow">'
+    j = string.find(message, suffix, i)
+    page.browser.get(message[i:j])
+
+
+def _follow_duplicate_account_email_link(page, email):
+    message = str(email.message())
+    prefix = 'please login: <a href="'
     i = string.find(message, prefix) + len(prefix)
     suffix = '" rel="nofollow">'
     j = string.find(message, suffix, i)

--- a/portal/tests/utils/teacher.py
+++ b/portal/tests/utils/teacher.py
@@ -61,6 +61,20 @@ def signup_teacher_directly(**kwargs):
     return email_address, password
 
 
+def signup_duplicate_teacher_fail(page, duplicate_email):
+    page = page.go_to_signup_page()
+
+    title, first_name, last_name, email_address, password = generate_details()
+    page = page.signup(title, first_name, last_name, duplicate_email, password, password)
+
+    page = page.return_to_home_page()
+
+    page = email.follow_duplicate_account_link_to_login(page, mail.outbox[0])
+    mail.outbox = []
+
+    return page, email_address, password
+
+
 def signup_teacher(page):
     page = page.go_to_signup_page()
 


### PR DESCRIPTION
Users who try to register using an email address already associated with an account will receive the following email:

Code for Life: Duplicate account error

A user is already registered with this email address: <email_address>.
If you've already registered, please login: <login_link>.
Otherwise please register with a different email address.