### PR TITLE
Resources page: fixes issues with PDFs 

### DIFF
--- a/portal/static/portal/sass/modules/_colours.scss
+++ b/portal/static/portal/sass/modules/_colours.scss
@@ -8,6 +8,7 @@ $color-text-secondary: #fff;
 $color-text-tertiary: $color-text-grey;
 $color-text-form-error: #f00;
 $color-text-login-error: #ff0;
+$color-text-materials-tag: #808080;
 //Quotes
 $color-quote-text: $color-teacher-blue;
 $color-quote-name: $color-text-grey;
@@ -52,6 +53,7 @@ $color-table-border: #9b9b9b;
 $color-background-primary: #000;
 $color-background-secondary: #fff;
 $color-background-tertiary: $color-text-grey;
+$color-background-materials-tag: #ccc;
 $color-background-teach: $color-teacher-blue;
 $color-background-play: $color-student-orange;
 $color-background-play-indep: #ff637d;

--- a/portal/static/portal/sass/partials/_utils.scss
+++ b/portal/static/portal/sass/partials/_utils.scss
@@ -94,7 +94,6 @@ section {
   margin-right: auto;
 }
 
-
 #faqs {
   answer,
   input {
@@ -114,7 +113,16 @@ section {
   }
 }
 
-
+.ks-tag
+{
+  @include _font-size(16px);
+  @include _margin(0px, 0px, 0px, 10px);
+  @include _padding(3px, 5px, 3px, 5px);
+  background-color: $color-background-materials-tag;
+  color: $color-text-materials-tag;
+  font-weight: normal;
+  vertical-align: middle;
+}
 
 .tab {
   list-style-type: none;

--- a/portal/templates/portal/teach/viewer.html
+++ b/portal/templates/portal/teach/viewer.html
@@ -24,7 +24,11 @@
 </div>
 
 <div class="banner banner--resources">
+    {% if video_link %}
     <div class="col-sm-4">
+    {% else %}
+    <div class="col-sm-8">
+    {% endif %}
         <h3>{{ title }}</h3>
         <h4>{{ description }}</h4>
         <div class="resource-buttons">

--- a/portal/views/teacher/pdfs.py
+++ b/portal/views/teacher/pdfs.py
@@ -337,7 +337,7 @@ PDF_DATA = {
 
     # ...KS1 Activity Set...#
     "ks1_activity_set": {
-        "title": "KS1 Activity Set",
+        "title": "KS1 - Activity Set",
         "description": "This activity set gives you an overview 0f the Key Stage 1 module. It covers the resources that will be useful, learning expectatins and teacher preparation.",
         "links": None,
         "url": "KS1/activity_set.pdf",
@@ -346,7 +346,7 @@ PDF_DATA = {
 
     # ...KS1 Assets...#
     "ks1_assets": {
-        "title": "KS1 Assets",
+        "title": "KS1 - Assets",
         "description": "Arrows, scenery and blockly statements that can be cut out for offline activities.",
         "links": ["ks1_code_wall_cards"],
         "url": "KS1/assets/assets.pdf",
@@ -354,7 +354,7 @@ PDF_DATA = {
     },
 
     "ks1_code_wall_cards": {
-        "title": "KS1 Code Wall Cards",
+        "title": "KS1 - Code Wall Cards",
         "description": "Keywords that can be displayed in the classroom.",
         "links": ["ks1_assets"],
         "url": "KS1/assets/code_wall_cards.pdf",
@@ -363,7 +363,7 @@ PDF_DATA = {
 
     # ...KS1 Assessments...#
     "ks1_assessment_guide": {
-        "title": "KS1 Assessment Guide",
+        "title": "KS1 - Assessment Guide",
         "description": "Information on how to use the assessment sheets available.",
         "links": ["ks1_self_assessment_sheet", "ks1_teacher_record_sheet"],
         "url": "KS1/assessment/assessment_sheet.pdf",
@@ -373,7 +373,7 @@ PDF_DATA = {
     "ks1_self_assessment_sheet": {
         "title": "KS1 - Self Assessment Sheet",
         "description": "Document for children to self assess their understanding of key concepts.",
-        "links": ["ks1_assessment_sheet", "ks1_teacher_record_sheet"],
+        "links": ["ks1_assessment_guide", "ks1_teacher_record_sheet"],
         "url": "KS1/assessment/self_assessment_sheet.pdf",
         "page_origin": "#ks1-assessments"
     },
@@ -381,7 +381,7 @@ PDF_DATA = {
     "ks1_teacher_record_sheet": {
         "title": "KS1 - Teacher Record Sheet",
         "description": "Document for the teacher to record pupils progress.",
-        "links": ["ks1_assessment_sheet", "ks1_self_assessment_sheet"],
+        "links": ["ks1_assessment_guide", "ks1_self_assessment_sheet"],
         "url": "KS1/assessment/teacher_record_sheet.pdf",
         "page_origin": "#ks1-assessments"
     },
@@ -581,7 +581,7 @@ PDF_DATA = {
 
     # ...LKS2 Activity Set...#
     "lks2_activity_set": {
-        "title": "Upper KS2 Activity Set",
+        "title": "Lower KS2 - Activity Set",
         "description": "This activity set gives you an overview of the Lower Key Stage 2 module. It covers the resources that will be useful, learning expectations and teacher preparation.",
         "links": None,
         "url": "KS2/activity_set.pdf",
@@ -590,7 +590,7 @@ PDF_DATA = {
 
     # ...LKS2 Assets...#
     "lks2_assets": {
-        "title": "Upper KS2 Assets",
+        "title": "Lower KS2 - Assets",
         "description": "Blockly statements for Lower Key Stage 2 children that can be cut out for offline activities.",
         "links": ["lks2_code_wall_cards"],
         "url": "KS2/assets/assets.pdf",
@@ -598,7 +598,7 @@ PDF_DATA = {
     },
 
     "lks2_code_wall_cards": {
-        "title": "Upper KS2 Code Wall Cards",
+        "title": "Lower KS2 - Code Wall Cards",
         "description": "Keywords that can be displayed in the classroom.",
         "links": ["lks2_assets"],
         "url": "KS2/assets/code_wall_cards.pdf",
@@ -607,7 +607,7 @@ PDF_DATA = {
 
     # ...LKS2 Assessments...#
     "lks2_assessment_guide": {
-        "title": "Upper KS2 Assessment Guide",
+        "title": "Lower KS2 - Assessment Guide",
         "description": "Information on how to use the assessment sheets available.",
         "links": ["lks2_self_assessment_sheet", "lks2_teacher_record_sheet"],
         "url": "KS2/assessment/assessment_sheet.pdf",
@@ -615,17 +615,17 @@ PDF_DATA = {
     },
 
     "lks2_self_assessment_sheet": {
-        "title": "Upper KS2 - Self Assessment Sheet",
+        "title": "Lower KS2 - Self Assessment Sheet",
         "description": "Document for children to self assess their understanding of key concepts.",
-        "links": ["lks2_assessment_sheet", "lks2_teacher_record_sheet"],
+        "links": ["lks2_assessment_guide", "lks2_teacher_record_sheet"],
         "url": "KS2/assessment/self_assessment_sheet.pdf",
         "page_origin": "#lks2-assessments"
     },
 
     "lks2_teacher_record_sheet": {
-        "title": "Upper KS2 - Teacher Record Sheet",
+        "title": "Lower KS2 - Teacher Record Sheet",
         "description": "Document for the teacher to record pupils progress.",
-        "links": ["lks2_assessment_sheet", "lks2_self_assessment_sheet"],
+        "links": ["lks2_assessment_guide", "lks2_self_assessment_sheet"],
         "url": "KS2/assessment/teacher_record_sheet.pdf",
         "page_origin": "#lks2-assessments"
     },
@@ -842,7 +842,7 @@ PDF_DATA = {
 
     # ...UKS2 Activity Set...#
     "uks2_activity_set": {
-        "title": "Upper KS2 Activity Set",
+        "title": "Upper KS2 - Activity Set",
         "description": "This activity set gives you an overview of the Upper Key Stage 2 module. It covers the resources that will be useful, learning expectations and teacher preparation.",
         "links": None,
         "url": "python/UKS2-AS-Activity-Set.pdf",
@@ -851,7 +851,7 @@ PDF_DATA = {
 
     # ...UKS2 Assets...#
     "uks2_assets": {
-        "title": "Upper KS2 Assets",
+        "title": "Upper KS2 - Assets",
         "description": "Blockly and Python statements for Upper Key Stage 2 children that can be cut out for offline activities.",
         "links": ["uks2_code_wall_cards"],
         "url": "python/UKS2-Assets.pdf",
@@ -859,7 +859,7 @@ PDF_DATA = {
     },
 
     "uks2_code_wall_cards": {
-        "title": "Upper KS2 Code Wall Cards",
+        "title": "Upper KS2 - Code Wall Cards",
         "description": "Keywords that can be displayed in the classroom.",
         "links": ["uks2_assets"],
         "url": "python/UKS2-Code_Wall_Cards.pdf",
@@ -868,7 +868,7 @@ PDF_DATA = {
 
     # ...UKS2 Assessments...#
     "uks2_assessment_guide": {
-        "title": "Upper KS2 Assessment Guide",
+        "title": "Upper KS2 - Assessment Guide",
         "description": "Information on how to use the assessment sheets available.",
         "links": ["uks2_self_assessment_sheet", "uks2_teacher_record_sheet"],
         "url": "python/assessment/UKS2-A-Assessment-tech.pdf",
@@ -878,7 +878,7 @@ PDF_DATA = {
     "uks2_self_assessment_sheet": {
         "title": "Upper KS2 - Self Assessment Sheet",
         "description": "Document for children to self assess their understanding of key concepts.",
-        "links": ["uks2_assessment_sheet", "uks2_teacher_record_sheet"],
+        "links": ["uks2_assessment_guide", "uks2_teacher_record_sheet"],
         "url": "python/assessment/UKS2-SA-Self-Assessment-Sheet.pdf",
         "page_origin": "#uks2-assessments"
     },
@@ -886,7 +886,7 @@ PDF_DATA = {
     "uks2_teacher_record_sheet": {
         "title": "Upper KS2 - Teacher Record Sheet",
         "description": "Document for the teacher to record pupils progress.",
-        "links": ["uks2_assessment_sheet", "uks2_self_assessment_sheet"],
+        "links": ["uks2_assessment_guide", "uks2_self_assessment_sheet"],
         "url": "python/assessment/UKS2-TRS.pdf",
         "page_origin": "#uks2-assessments"
     }


### PR DESCRIPTION
- LKS2 assessment guide, self-assessment sheet and teacher record sheet now show the right PDF in the viewer and provide the correct PDF to download.
- LKS2 'extra' resources show the correct title in the PDF viewer.
- Links to any key stage's assessment guide from the self-assessment sheet and the teacher record sheet pages now link to the correct PDFs and do not raise a 404 error.
- Added `-` to some of the PDF viewer pages' titles to stay consistent.
- Reincorporated the CSS for the KS tags which had mysteriously disappeared...