### PR TITLE
Teacher dashboard: fixed forms for non-admin teachers

### DIFF
--- a/portal/tests/test_class.py
+++ b/portal/tests/test_class.py
@@ -84,6 +84,24 @@ class TestClass(BaseTest):
 
         assert is_class_created_message_showing(selenium, class_name)
 
+    def test_create_dashboard_non_admin(self):
+        email_1, password_1 = signup_teacher_directly()
+        email_2, password_2 = signup_teacher_directly()
+        name, postcode = create_organisation_directly(email_1)
+        klass_1, class_name_1, access_code_1 = create_class_directly(email_1)
+        create_school_student_directly(access_code_1)
+        join_teacher_to_organisation(email_2, name, postcode)
+        klass_2, class_name_2, access_code_2 = create_class_directly(email_2)
+        create_school_student_directly(access_code_2)
+
+        page = self.go_to_homepage() \
+            .go_to_login_page() \
+            .login(email_2, password_2)
+
+        page, class_name_3 = create_class(page)
+
+        assert is_class_created_message_showing(selenium, class_name_3)
+
     def test_delete_empty(self):
         email, password = signup_teacher_directly()
         create_organisation_directly(email)

--- a/portal/views/teacher/dashboard.py
+++ b/portal/views/teacher/dashboard.py
@@ -87,8 +87,8 @@ def dashboard_teacher_view(request, is_admin):
 
     backup_tokens = check_backup_tokens(request)
 
-    if can_process_forms(request, is_admin):
-        if 'update_school' in request.POST:
+    if request.method == 'POST':
+        if can_process_update_school_form(request, is_admin):
             anchor = 'school-details'
             update_school_form = OrganisationForm(request.POST, user=request.user, current_school=school)
             anchor = process_update_school_form(request, school, anchor)
@@ -127,8 +127,8 @@ def dashboard_teacher_view(request, is_admin):
     })
 
 
-def can_process_forms(request, is_admin):
-    return request.method == 'POST' and is_admin
+def can_process_update_school_form(request, is_admin):
+    return 'update_school' in request.POST and is_admin
 
 
 def check_backup_tokens(request):


### PR DESCRIPTION
Following issue #598:
- The 'Add class' and 'Edit account details' forms in dashboard work also for non-admin teachers.
- Tests have been added to ensure a similar issue doesn't arise again.

The problem was that the back end was checking whether a teacher is a admin for every form in the dashboard, whereas it actually needs to check that only for the 'Edit school details' form.