### PR TITLE
Adding students from dashboard page has correct button in nav bar

### DIFF
--- a/portal/templates/portal/teach/onboarding_print.html
+++ b/portal/templates/portal/teach/onboarding_print.html
@@ -55,7 +55,7 @@
         <div class='section'>
             <button class='button--regular button--primary--navigation' type='submit'>Print reminder cards</button>
             {% if onboarding_done %}
-            <a href="{% url 'view_class' class.access_code %}" class="button button--regular button--secondary button--secondary--dark">Back to class</a>
+            <a id="back_to_class_button" href="{% url 'view_class' class.access_code %}" class="button button--regular button--secondary button--secondary--dark">Back to class</a>
             {% else %}
             <a href="{% url 'onboarding-complete' %}" class="button button--regular button--secondary button--secondary--dark">Finish setup</a>
             {% endif %}
@@ -98,7 +98,7 @@
                 <div class='button-group'>
                     <button class='button--regular button--primary--navigation' type='submit'>Print reminder cards</button>
                     {% if onboarding_done %}
-                        <a id="back_to_class_button" href="{% url 'view_class' class.access_code %}" class="button button--regular button--secondary button--secondary--dark">Back to class</a>
+                        <a href="{% url 'view_class' class.access_code %}" class="button button--regular button--secondary button--secondary--dark">Back to class</a>
                     {% else %}
                         <a href="{% url 'onboarding-complete' %}" class="button button--regular button--secondary button--secondary--dark">Finish setup</a>
                     {% endif %}

--- a/portal/templates/portal/teach/onboarding_print.html
+++ b/portal/templates/portal/teach/onboarding_print.html
@@ -54,7 +54,11 @@
         <input type='hidden' name='data' value='{{ query_data }}'/>
         <div class='section'>
             <button class='button--regular button--primary--navigation' type='submit'>Print reminder cards</button>
+            {% if onboarding_done %}
+            <a href="{% url 'view_class' class.access_code %}" class="button button--regular button--secondary button--secondary--dark">Back to class</a>
+            {% else %}
             <a href="{% url 'onboarding-complete' %}" class="button button--regular button--secondary button--secondary--dark">Finish setup</a>
+            {% endif %}
         </div>
     </form>
 </div>


### PR DESCRIPTION
Button now says 'Back to class' instead of 'Finish setup'... and redirects to class rather than finishing the setup.