### PR TITLE
Student edit account page: tests and correct redirect

### DIFF
--- a/portal/forms/play.py
+++ b/portal/forms/play.py
@@ -131,8 +131,7 @@ class StudentEditAccountForm(forms.Form):
     def clean_password(self):
         password = self.cleaned_data.get('password', None)
 
-        if password and not password_strength_test(password, length=6, upper=False, lower=False,
-                                                   numbers=False):
+        if password and not password_strength_test(password, length=6, upper=False, lower=False, numbers=False):
             raise forms.ValidationError(
                 "Password not strong enough, consider using at least 6 characters")
 
@@ -143,10 +142,10 @@ class StudentEditAccountForm(forms.Form):
         confirm_password = self.cleaned_data.get('confirm_password', None)
         current_password = self.cleaned_data.get('current_password', None)
 
-        if (password or confirm_password) and password != confirm_password:
+        if password is not None and (password or confirm_password) and password != confirm_password:
             raise forms.ValidationError("Your new passwords do not match")
 
-        if not self.user.check_password(current_password):
+        if current_password and not self.user.check_password(current_password):
             raise forms.ValidationError("Your current password was incorrect")
 
         return self.cleaned_data

--- a/portal/templates/portal/play/student_edit_account.html
+++ b/portal/templates/portal/play/student_edit_account.html
@@ -37,7 +37,7 @@
                     <p>Your password must be long enough and hard enough to stop your friends guessing it and stealing all of your hard work.</p>
                 {% endif %}
 
-                <form method='post'>
+                <form id="student_account_form" method='post'>
 
                     {% csrf_token %}
 

--- a/portal/templates/portal/play/student_join_organisation.html
+++ b/portal/templates/portal/play/student_join_organisation.html
@@ -63,7 +63,7 @@
 
                 <p>If successful, the teacher will contact you with your new login details.</p>
 
-                <form method='post'>
+                <form id="join_class_form" method='post'>
 
                     {% csrf_token %}
 

--- a/portal/tests/pageObjects/portal/login_page.py
+++ b/portal/tests/pageObjects/portal/login_page.py
@@ -122,12 +122,8 @@ class LoginPage(BasePage):
         error = 'Incorrect email address or password'
         return error in errors
 
-    def has_student_login_failed(self):
-        if not self.element_exists_by_css('.errorlist'):
-            return False
-
+    def has_student_login_failed(self, error):
         errors = self.browser.find_element_by_id('form-login-school').find_element_by_class_name('errorlist').text
-        error = 'Invalid name, class access code or password'
         return error in errors
 
     def has_independent_student_login_failed(self):

--- a/portal/tests/pageObjects/portal/login_page.py
+++ b/portal/tests/pageObjects/portal/login_page.py
@@ -114,24 +114,8 @@ class LoginPage(BasePage):
         self.browser.find_element_by_id('id_independent_student-password').send_keys(password)
         self.browser.find_element_by_name('independent_student_login').click()
 
-    def has_login_failed(self):
-        if not self.element_exists_by_css('.errorlist'):
-            return False
-
-        errors = self.browser.find_element_by_id('form-login-teacher').find_element_by_class_name('errorlist').text
-        error = 'Incorrect email address or password'
-        return error in errors
-
-    def has_student_login_failed(self, error):
-        errors = self.browser.find_element_by_id('form-login-school').find_element_by_class_name('errorlist').text
-        return error in errors
-
-    def has_independent_student_login_failed(self):
-        if not self.element_exists_by_css('.errorlist'):
-            return False
-
-        errors = self.browser.find_element_by_id('independent_student_login_form').find_element_by_class_name('errorlist').text
-        error = 'Incorrect username or password'
+    def has_login_failed(self, form_id, error):
+        errors = self.browser.find_element_by_id(form_id).find_element_by_class_name('errorlist').text
         return error in errors
 
     def go_to_teacher_forgotten_password_page(self):

--- a/portal/tests/pageObjects/portal/play/account_page.py
+++ b/portal/tests/pageObjects/portal/play/account_page.py
@@ -35,6 +35,7 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 from play_base_page import PlayBasePage
+from portal.tests.pageObjects.portal.play.dashboard_page import PlayDashboardPage
 
 
 class PlayAccountPage(PlayBasePage):
@@ -51,3 +52,34 @@ class PlayAccountPage(PlayBasePage):
 
         return correct
 
+    def submit_empty_form(self):
+        self.browser.find_element_by_id('update_button').click()
+        return self
+
+    def update_password_failure(self, new_password, confirm_new_password, old_password):
+        self._update_password(new_password, confirm_new_password, old_password)
+        return self
+
+    def update_password_success(self, new_password, confirm_new_password, old_password):
+        self._update_password(new_password, confirm_new_password, old_password)
+        return PlayDashboardPage(self.browser)
+
+    def update_name(self, new_name, password):
+        self._update_name(new_name, password)
+        return PlayDashboardPage(self.browser)
+
+    def _update_password(self, new_password, confirm_new_password, old_password):
+        self.browser.find_element_by_id('id_password').send_keys(new_password)
+        self.browser.find_element_by_id('id_confirm_password').send_keys(confirm_new_password)
+        self.browser.find_element_by_id('id_current_password').send_keys(old_password)
+        self.browser.find_element_by_id('update_button').click()
+
+    def _update_name(self, new_name, password):
+        self.browser.find_element_by_id('id_name').clear()
+        self.browser.find_element_by_id('id_name').send_keys(new_name)
+        self.browser.find_element_by_id('id_current_password').send_keys(password)
+        self.browser.find_element_by_id('update_button').click()
+
+    def was_form_invalid(self, error):
+        errors = self.browser.find_element_by_id('student_account_form').find_element_by_class_name('errorlist').text
+        return error in errors

--- a/portal/tests/pageObjects/portal/play/account_page.py
+++ b/portal/tests/pageObjects/portal/play/account_page.py
@@ -64,7 +64,11 @@ class PlayAccountPage(PlayBasePage):
         self._update_password(new_password, confirm_new_password, old_password)
         return PlayDashboardPage(self.browser)
 
-    def update_name(self, new_name, password):
+    def update_name_failure(self, new_name, password):
+        self._update_name(new_name, password)
+        return self
+
+    def update_name_success(self, new_name, password):
         self._update_name(new_name, password)
         return PlayDashboardPage(self.browser)
 

--- a/portal/tests/pageObjects/portal/play/join_school_or_club_page.py
+++ b/portal/tests/pageObjects/portal/play/join_school_or_club_page.py
@@ -50,6 +50,17 @@ class JoinSchoolOrClubPage(PlayBasePage):
 
         return self
 
+    def join_a_school_or_club_failure(self, access_code):
+        self.browser.find_element_by_id('id_access_code').send_keys(access_code)
+        self.browser.find_element_by_id('request_join_a_school_or_club_button').click()
+        assert not self.element_exists_by_css('.success')
+
+        return self
+
+    def has_join_request_failed(self, error):
+        errors = self.browser.find_element_by_id('join_class_form').find_element_by_class_name('errorlist').text
+        return error in errors
+
     def revoke_join_request(self):
         self.browser.find_element_by_name('revoke_join_request').click()
 

--- a/portal/tests/pageObjects/portal/play/join_school_or_club_page.py
+++ b/portal/tests/pageObjects/portal/play/join_school_or_club_page.py
@@ -49,3 +49,8 @@ class JoinSchoolOrClubPage(PlayBasePage):
         assert self.element_exists_by_css('.success')
 
         return self
+
+    def revoke_join_request(self):
+        self.browser.find_element_by_name('revoke_join_request').click()
+
+        return self

--- a/portal/tests/pageObjects/portal/signup_page.py
+++ b/portal/tests/pageObjects/portal/signup_page.py
@@ -72,10 +72,6 @@ class SignupPage(BasePage):
         else:
             return self
 
-    def has_independent_student_signup_failed(self):
-        if not self.element_exists_by_css('.errorlist'):
-            return False
-
+    def has_independent_student_signup_failed(self, error):
         errors = self.browser.find_element_by_id('form-signup-independent-student').find_element_by_class_name('errorlist').text
-        error = 'Password not strong enough, consider using at least 6 characters'
         return error in errors

--- a/portal/tests/test_independent_student.py
+++ b/portal/tests/test_independent_student.py
@@ -107,7 +107,7 @@ class TestIndependentStudent(BaseTest):
         page = page.go_to_login_page()
         page = page.independent_student_login_failure('Non existent username', 'Incorrect password')
 
-        assert page.has_independent_student_login_failed()
+        assert page.has_login_failed('independent_student_login_form', 'Incorrect username or password')
 
     def test_login_success(self):
         page = self.go_to_homepage()

--- a/portal/tests/test_school_student.py
+++ b/portal/tests/test_school_student.py
@@ -70,7 +70,7 @@ class TestSchoolStudent(BaseTest):
             .go_to_login_page()\
             .student_login_failure(student_name, access_code, 'some other password')
 
-        assert page.has_student_login_failed('Invalid name, class access code or password')
+        assert page.has_login_failed('form-login-school', 'Invalid name, class access code or password')
 
     def test_login_nonexistent_class(self):
         email, password = signup_teacher_directly()
@@ -83,7 +83,7 @@ class TestSchoolStudent(BaseTest):
             .go_to_login_page() \
             .student_login_failure(student_name, 'WRONG', student_password)
 
-        assert page.has_student_login_failed('Invalid name, class access code or password')
+        assert page.has_login_failed('form-login-school', 'Invalid name, class access code or password')
 
     def test_login_empty_class(self):
         email, password = signup_teacher_directly()
@@ -97,7 +97,7 @@ class TestSchoolStudent(BaseTest):
             .go_to_login_page() \
             .student_login_failure(student_name, access_code2, student_password)
 
-        assert page.has_student_login_failed('Invalid name, class access code or password')
+        assert page.has_login_failed('form-login-school', 'Invalid name, class access code or password')
 
     def test_update_password_form_empty(self):
         email, password = signup_teacher_directly()

--- a/portal/tests/test_school_student.py
+++ b/portal/tests/test_school_student.py
@@ -70,7 +70,34 @@ class TestSchoolStudent(BaseTest):
             .go_to_login_page()\
             .student_login_failure(student_name, access_code, 'some other password')
 
-        assert page.has_student_login_failed()
+        assert page.has_student_login_failed('Invalid name, class access code or password')
+
+    def test_login_nonexistent_class(self):
+        email, password = signup_teacher_directly()
+        create_organisation_directly(email)
+        _, class_name, access_code = create_class_directly(email)
+        student_name, student_password, _ = create_school_student_directly(access_code)
+
+        selenium.get(self.live_server_url)
+        page = HomePage(selenium) \
+            .go_to_login_page() \
+            .student_login_failure(student_name, 'WRONG', student_password)
+
+        assert page.has_student_login_failed('Invalid name, class access code or password')
+
+    def test_login_empty_class(self):
+        email, password = signup_teacher_directly()
+        create_organisation_directly(email)
+        _, class_name, access_code = create_class_directly(email)
+        student_name, student_password, _ = create_school_student_directly(access_code)
+        _, class_name2, access_code2 = create_class_directly(email)
+
+        selenium.get(self.live_server_url)
+        page = HomePage(selenium) \
+            .go_to_login_page() \
+            .student_login_failure(student_name, access_code2, student_password)
+
+        assert page.has_student_login_failed('Invalid name, class access code or password')
 
     def test_update_password_form_empty(self):
         email, password = signup_teacher_directly()

--- a/portal/tests/test_teacher.py
+++ b/portal/tests/test_teacher.py
@@ -76,7 +76,7 @@ class TestTeacher(BaseTest):
         page = HomePage(selenium)
         page = page.go_to_login_page()
         page = page.login_failure('non-existent-email@codeforlife.com', 'Incorrect password')
-        assert page.has_login_failed()
+        assert page.has_login_failed('form-login-teacher', 'Incorrect email address or password')
 
     def test_login_success(self):
         email, password = signup_teacher_directly()

--- a/portal/tests/utils/messages.py
+++ b/portal/tests/utils/messages.py
@@ -48,6 +48,18 @@ def is_teacher_details_updated_message_showing(browser):
     return is_message_showing(browser, 'Your account details have been successfully changed.')
 
 
+def is_student_details_updated_message_showing(browser):
+    return is_message_showing(browser, 'Your account details have been changed successfully.')
+
+
+def is_indep_student_join_request_received_message_showing(browser):
+    return is_message_showing(browser, 'Your request to join a school has been received successfully.')
+
+
+def is_indep_student_join_request_revoked_message_showing(browser):
+    return is_message_showing(browser, 'Your request to join a school has been cancelled successfully.')
+
+
 def is_teacher_email_updated_message_showing(browser):
     return is_message_showing(browser, 'Your account details have been successfully changed. Your email will be '
                                        'changed once you have verified it, until then you can still log in with your '

--- a/portal/views/play.py
+++ b/portal/views/play.py
@@ -56,14 +56,14 @@ from ratelimit.decorators import ratelimit
 recaptcha_client = RecaptchaClient(app_settings.RECAPTCHA_PRIVATE_KEY, app_settings.RECAPTCHA_PUBLIC_KEY)
 
 
-@login_required(login_url=reverse_lazy('play'))
-@user_passes_test(logged_in_as_student, login_url=reverse_lazy('play'))
+@login_required(login_url=reverse_lazy('login_view'))
+@user_passes_test(logged_in_as_student, login_url=reverse_lazy('login_view'))
 def student_details(request):
     return render(request, 'portal/play/student_details.html')
 
 
-@login_required(login_url=reverse_lazy('play'))
-@user_passes_test(logged_in_as_student, login_url=reverse_lazy('play'))
+@login_required(login_url=reverse_lazy('login_view'))
+@user_passes_test(logged_in_as_student, login_url=reverse_lazy('login_view'))
 def student_edit_account(request):
     student = request.user.new_student
 
@@ -74,7 +74,7 @@ def student_edit_account(request):
             changing_email = False
 
             # check not default value for CharField
-            if (data['password'] != ''):
+            if data['password'] != '':
                 student.new_user.set_password(data['password'])
                 student.new_user.save()
                 update_session_auth_hash(request, form.user)
@@ -110,8 +110,8 @@ def username_labeller(request):
     return request.user.username
 
 
-@login_required(login_url=reverse_lazy('play'))
-@user_passes_test(logged_in_as_student, login_url=reverse_lazy('play'))
+@login_required(login_url=reverse_lazy('login_view'))
+@user_passes_test(logged_in_as_student, login_url=reverse_lazy('login_view'))
 @ratelimit('ip', labeller=username_labeller, periods=['1m'], increment=lambda req, res: hasattr(res, 'count') and res.count)
 def student_join_organisation(request):
     increment_count = False


### PR DESCRIPTION
- Tests now cover when students/indep students edit their details (name, password, etc...), which also includes cases where the form is invalid.
- If a student tries to load these pages without being logged in they will now be redirected appropriately to the login page.