### PR TITLE
Re-sets Coveralls properly

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,0 @@
-[report]
-omit =
-    */tests/*
-    */python?.?/*
-    *ratelimit/*
-    *portal/migrations/*
-    *.eggs/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ before_script:
 script:
   - python setup.py test
 after_success:
-  - coveralls --rcfile=.coveragerc
+  - coveralls
 git:
   depth: 9999999 # Building untagged builds needs enough depth to get the latest tag
 deploy:

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,6 +4,9 @@ universal = 1
 [coverage:run]
 source = portal,ratelimit,reports
 
+[report]
+omit = *_version.py
+
 [pep8]
 max-line-length = 160
 


### PR DESCRIPTION
Following @mikebryant's suggestions, Coveralls should check:
- test files
- ratelimit
- migrations

The only file which should be excluded in the portal folder is _versions.py.