### PR TITLE
School creation page: clearer postcode error message

### DIFF
--- a/portal/forms/organisation.py
+++ b/portal/forms/organisation.py
@@ -52,14 +52,14 @@ class OrganisationForm(forms.ModelForm):
         model = School
         fields = ['name', 'postcode', 'country']
         labels = {
-            'name' : "Name of your school or club",
-            'postcode' : 'Postcode',
-            'country' : 'Country',
+            'name': "Name of your school or club",
+            'postcode': 'Postcode',
+            'country': 'Country',
             }
         widgets = {
-            'name' : forms.TextInput(attrs={'autocomplete': "off", 'placeholder': 'Name of your school or club'}),
-            'postcode' : forms.TextInput(attrs={'autocomplete': "off", 'placeholder': 'Postcode'}),
-            'country' : CountrySelectWidget(attrs={'class': 'wide'}),
+            'name': forms.TextInput(attrs={'autocomplete': "off", 'placeholder': 'Name of your school or club'}),
+            'postcode': forms.TextInput(attrs={'autocomplete': "off", 'placeholder': 'Postcode'}),
+            'country': CountrySelectWidget(attrs={'class': 'wide'}),
             }
 
     def __init__(self, *args, **kwargs):
@@ -89,9 +89,8 @@ class OrganisationForm(forms.ModelForm):
         postcode = self.cleaned_data.get('postcode', None)
 
         if postcode:
-            # Basic postcode check for now
-            if not len(postcode.replace(' ', '')) > 0:
-                raise forms.ValidationError("That postcode was not recognised")
+            if len(postcode.replace(' ', '')) > 10 or len(postcode.replace(' ', '')) == 0:
+                raise forms.ValidationError("Please enter a valid postcode or ZIP code")
 
         return postcode
 

--- a/portal/templates/portal/teach/onboarding_school.html
+++ b/portal/templates/portal/teach/onboarding_school.html
@@ -81,9 +81,9 @@
                 {{ create_form.non_field_errors }}
 
                 {% for field in create_form %}
-                {{ field.errors }}
                 <label for="id_{{ field.name }}">{{ field.label }}</label>
                 {{ field }}
+                {{ field.errors }}
                 {% endfor %}
 
                 <div class='section group'>
@@ -99,18 +99,18 @@
 
                 {{ join_form.non_field_errors }}
 
-                {{ join_form.fuzzy_name.errors }}
                 <label for="id_{{ join_form.fuzzy_name.html_name }}">{{ join_form.fuzzy_name.label }}</label>
                 {{ join_form.fuzzy_name }}
+                {{ join_form.fuzzy_name.errors }}
 
-                {{ join_form.chosen_org.errors }}
                 <label for="id_{{ join_form.chosen_org.html_name }}">{{ join_form.chosen_org.label }}</label>
                 {{ join_form.chosen_org }}
+                {{ join_form.chosen_org.errors }}
 
                 {% if join_form.recaptcha %}
-                {{ join_form.recaptcha.errors }}
                 <label for="id_{{ join_form.recaptcha.html_name }}">{{ join_form.recaptcha.label }}</label>
                 {{ join_form.recaptcha|safe }}
+                {{ join_form.recaptcha.errors }}
                 {% endif %}
 
                 <div class='section group'>

--- a/portal/tests/pageObjects/portal/teach/onboarding_organisation_page.py
+++ b/portal/tests/pageObjects/portal/teach/onboarding_organisation_page.py
@@ -96,6 +96,11 @@ class OnboardingOrganisationPage(TeachBasePage):
         error = 'There is already a school or club registered with that name and postcode'
         return error in errors
 
+    def was_postcode_invalid(self):
+        errors = self.browser.find_element_by_id('form-create-organisation').find_element_by_class_name('errorlist').text
+        error = 'Please enter a valid postcode or ZIP code'
+        return error in errors
+
     def join_organisation(self, name):
         self.browser.find_element_by_id('join-tab').click()
         self.browser.find_element_by_id('id_fuzzy_name').send_keys(name)

--- a/portal/tests/test_organisation.py
+++ b/portal/tests/test_organisation.py
@@ -96,6 +96,15 @@ class TestOrganisation(BaseTest, BasePage):
 
         assert page.has_creation_failed()
 
+    def test_create_invalid_postcode(self):
+        email, password = signup_teacher_directly()
+
+        selenium.get(self.live_server_url)
+        page = HomePage(selenium).go_to_login_page().login_no_school(email, password)
+
+        page = page.create_organisation_failure('School', password, '   ')
+        assert page.was_postcode_invalid()
+
     def test_revoke(self):
         email_1, password_1 = signup_teacher_directly()
         email_2, password_2 = signup_teacher_directly()


### PR DESCRIPTION
- Error messages have been moved under the fields instead of below.
- The error message for the postcode now reads 'Please enter a valid postcode or ZIP code'.
- Tests!
- Other minor PEP8 fixes.