### PR TITLE
Add contact recaptcha and limit only captcha to signup

### DIFF
--- a/portal/forms/play.py
+++ b/portal/forms/play.py
@@ -168,6 +168,8 @@ class StudentSignupForm(forms.Form):
         label='Confirm Password',
         widget=forms.PasswordInput)
 
+    captcha = ReCaptchaField()
+
     def clean_name(self):
         name = self.cleaned_data.get('name', None)
         if re.match(re.compile('^[\w ]+$'), name) is None:

--- a/portal/forms/teach.py
+++ b/portal/forms/teach.py
@@ -95,6 +95,8 @@ class TeacherSignupForm(forms.Form):
         widget=forms.PasswordInput()
     )
 
+    captcha = ReCaptchaField()
+
     def clean_teacher_password(self):
         password = self.cleaned_data.get('teacher_password', None)
 

--- a/portal/templates/portal/help-and-support.html
+++ b/portal/templates/portal/help-and-support.html
@@ -289,10 +289,13 @@
                     </div>
                 </div>
                 {{ form.browser }}
-
-                {% if captcha %}
-                    {{ form.captcha }}
-                {% endif %}
+				<div class="row">
+					<div class="col-sm-6">
+					{% if captcha %}
+					{{ form.captcha }}
+					{% endif %}
+					</div>
+				</div>
 
                 <section>
                     <button type="submit" name="submit" value="Submit" class="button--regular button--primary--general-play">Submit</button>

--- a/portal/templates/portal/register.html
+++ b/portal/templates/portal/register.html
@@ -59,6 +59,12 @@
                     </div>
                 </div>
 
+                <div class="row">
+                    {% if captcha %}
+                    {{ teacher_signup_form.captcha }}
+                    {% endif %}
+                </div>
+
                 <button class="button--big button--primary--general-educate" type="submit" name="teacher_signup">Register</button>
             </form>
 
@@ -99,6 +105,12 @@
                         <div id="student-password-sign" class='password-strength-sign'></div>
                         <div id="student-password-text" class='password-strength-text'></div>
                     </div>
+                </div>
+
+                <div class="row">
+                    {% if captcha %}
+                    {{ student_signup_form.captcha }}
+                    {% endif %}
                 </div>
 
                 <button type='submit' name='student_signup' class="button--big button--primary--general-play" value='Register'>Register</button>

--- a/portal/views/home.py
+++ b/portal/views/home.py
@@ -324,9 +324,7 @@ def redirect_user_to_correct_page(request, teacher):
 @ratelimit('ip', periods=['1m'], increment=lambda req, res: hasattr(res, 'count') and res.count)
 def contact(request):
     increment_count = False
-    limits = getattr(request, 'limits', {'ip': [0]})
-    captcha_limit = 5
-    should_use_captcha = (limits['ip'][0] >= captcha_limit) and captcha.CAPTCHA_ENABLED
+    should_use_captcha = captcha.CAPTCHA_ENABLED
 
     anchor = ''
 

--- a/portal/views/home.py
+++ b/portal/views/home.py
@@ -167,7 +167,9 @@ def configure_login_form_captcha(form, render_dict, render_dict_captcha_key):
 @ratelimit('name', labeller=play_name_labeller, ip=False, periods=['1m'], increment=lambda req, res: hasattr(res, 'count') and res.count)
 def render_signup_form(request):
     invalid_form = False
-    should_use_captcha = captcha.CAPTCHA_ENABLED
+    limits = getattr(request, 'limits', {'ip': [0]})
+    captcha_limit = 5
+    should_use_captcha = (limits['ip'][0] >= captcha_limit) and captcha.CAPTCHA_ENABLED
 
     teacher_signup_form = TeacherSignupForm(prefix='teacher_signup')
     student_signup_form = StudentSignupForm(prefix='student_signup')


### PR DESCRIPTION
- Adds a constant contact page recaptcha. 
- When limits exceeded, signup also gets a recaptcha.

Few things stopping me here is form error messages, decided not to because of #674 and tests #295 #295. The way the code is architectured means that recaptcha is disabled for tests right now. Out of scope for this PR.

So.... test manually? ;p

See below. 

<img width="1611" alt="screen shot 2018-03-21 at 15 32 55" src="https://user-images.githubusercontent.com/22431381/37722043-057bff4a-2d23-11e8-8dbd-455d948fd145.png">

<img width="1563" alt="screen shot 2018-03-21 at 15 33 06" src="https://user-images.githubusercontent.com/22431381/37722066-16f5c328-2d23-11e8-9d8e-a93f30f83d0f.png">
