### PR TITLE
fixes #677 Replace GET with POST when necessary, and refactored a bit…

### DIFF
--- a/portal/static/portal/js/common.js
+++ b/portal/static/portal/js/common.js
@@ -87,6 +87,12 @@ function openConfirmationBox(name) {
     $('#confirmation-dialog').dialog('open');
 }
 
+function postWithCsrf(path) {
+    post(path, {
+        csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val()
+    });
+}
+
 $(function() {
     $('#confirmation-dialog').dialog(defaultConfirmationOptions);
 });

--- a/portal/static/portal/js/organisation_manage.js
+++ b/portal/static/portal/js/organisation_manage.js
@@ -37,6 +37,8 @@ identified as the original program.
 */
 
 /* global post */
+/* global openConfirmationBox */
+/* global postWithCsrf */
 
 function showRemoveConfirmation(path, name) {
     CONFIRMATION_DATA.remove = {
@@ -44,7 +46,7 @@ function showRemoveConfirmation(path, name) {
             title: 'Remove teacher'
         },
         html: '<p>The teacher "'+name+'", will be removed from the school or club. If they have any classes you will be asked to move them to other teachers of this school or club.</p><p>Are you sure?</p>',
-        confirm: function() { window.location.replace(path); }
+        confirm: function() { postWithCsrf(path); }
     };
     openConfirmationBox('remove');
 }
@@ -55,7 +57,7 @@ function showToggleAdminConfirmation(path, name) {
             title: 'Set administrator permissions'
         },
         html: '<p>The teacher "'+name+'", will be made an administrator of this school or club. They will gain all of the powers that you currently have.</p><p>Are you sure?</p>',
-        confirm: function() { toggleAdmin(path); }
+        confirm: function() { postWithCsrf(path); }
     };
     openConfirmationBox('remove');
 }
@@ -66,14 +68,7 @@ function showDisable2FAConfirmation(path, name) {
             title: 'Disable 2FA for '+name
         },
         html: '<p>The teacher "'+name+'", will have their two factor authentication disabled. This will make their account less secure.</p><p>Are you sure?</p>',
-        confirm: function() { window.location.replace(path); }
+        confirm: function() { postWithCsrf(path); }
     };
     openConfirmationBox('remove');
 }
-
-function toggleAdmin(path) {
-    post(path, {
-        csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val()
-    });
-}
-

--- a/portal/static/portal/js/teach_class.js
+++ b/portal/static/portal/js/teach_class.js
@@ -38,6 +38,7 @@ identified as the original program.
 
 /* global post */
 /* global openConfirmationBox */
+/* global postWithCsrf */
 
 var CONFIRMATION_DATA = {};
 
@@ -89,7 +90,7 @@ $(function() {
     });
 
     $("#deleteClass").click(function() {
-        openConfirmationBox('deleteClass');
+        openConfirmationBox('delete');
         return false;
     });
 });
@@ -100,7 +101,7 @@ function deleteClassConfirmation(path) {
             title: 'Delete class'
         },
         html: '<p class="body-text">This class will be permanently deleted. Are you sure?</p>',
-        confirm: function() { window.location.replace(path); }
+        confirm: function() { postWithCsrf(path); }
     };
     openConfirmationBox('delete');
 }

--- a/portal/templates/portal/teach/dashboard.html
+++ b/portal/templates/portal/teach/dashboard.html
@@ -83,7 +83,7 @@
                 {% if coworker.new_user != user %}
                     <td class="cell-center">
                         <button id="kick_button" class="button--small button--primary--danger"
-                                onclick="showRemoveConfirmation('{% url 'organisation_kick' coworker.id %}', '{{ coworker.new_user.first_name|striptags | escapejs }}')">
+                                onclick="showRemoveConfirmation('{% url 'organisation_kick' coworker.id %}', '{{ coworker.new_user.first_name|striptags | escapejs }}', '{True}')">
                             Remove</button>
                     </td>
                     <td class="cell-center">
@@ -154,11 +154,15 @@
                                     {{ join_request.new_user.last_name }}</small></p></td>
                                 <td><p><small>{{ join_request.new_user.email }}</small></p></td>
                                 <td class="cell-center">
-                                    <a id="allow_button" class="button button--small button-primary button--primary--positive"
-                                            href="{% url 'organisation_allow_join' join_request.id %}">Allow</a></td>
+                                     <button id="allow_button" class="button button--small button-primary button--primary--positive"
+                                            onclick="post('{% url 'organisation_allow_join' join_request.id %}', {
+                                                csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val()});">Allow</button>
+                                </td>
                                 <td class="cell-center">
-                                    <a id="deny_button" class="button button--small button-primary button--primary--danger"
-                                            href="{% url 'organisation_deny_join' join_request.id %}">Deny</a></td>
+                                     <button id="deny_button" class="button button--small button-primary button--primary--danger"
+                                        onclick="post('{% url 'organisation_deny_join' join_request.id %}', {
+                                                csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val()});">Deny</button>
+                                </td>
                             </tr>
                         {% endfor %}
                     </table>

--- a/portal/templates/portal/teach/dashboard.html
+++ b/portal/templates/portal/teach/dashboard.html
@@ -89,8 +89,7 @@
                     <td class="cell-center">
                         {% if coworker.is_admin %}
                             <button id="make_non_admin_button" class='button button--small button--primary--navigation'
-                               onclick="post('{% url 'organisation_toggle_admin' coworker.id %}', {
-                                   csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val()});">Make non-admin</button>
+                               onclick="postWithCsrf('{% url 'organisation_toggle_admin' coworker.id %}');">Make non-admin</button>
                         {% else %}
                             <button id="make_admin_button" class="button--small button--primary--navigation"
                                     onclick="showToggleAdminConfirmation('{% url 'organisation_toggle_admin' coworker.id %}', '{{ coworker.new_user.first_name|striptags | escapejs}}')">
@@ -155,13 +154,11 @@
                                 <td><p><small>{{ join_request.new_user.email }}</small></p></td>
                                 <td class="cell-center">
                                      <button id="allow_button" class="button button--small button-primary button--primary--positive"
-                                            onclick="post('{% url 'organisation_allow_join' join_request.id %}', {
-                                                csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val()});">Allow</button>
+                                            onclick="postWithCsrf('{% url 'organisation_allow_join' join_request.id %}');">Allow</button>
                                 </td>
                                 <td class="cell-center">
                                      <button id="deny_button" class="button button--small button-primary button--primary--danger"
-                                        onclick="post('{% url 'organisation_deny_join' join_request.id %}', {
-                                                csrfmiddlewaretoken: $('input[name=csrfmiddlewaretoken]').val()});">Deny</button>
+                                        onclick="postWithCsrf('{% url 'organisation_deny_join' join_request.id %}');">Deny</button>
                                 </td>
                             </tr>
                         {% endfor %}


### PR DESCRIPTION
… the post utils in js

The following requests are now using POST instead of GET:
- allow a teacher to join school
- deny a teacher to join school
- remove a class
- kick a teacher (not found in the test)

Assigning / unassigning school admins: was POST already (tested on codeforlife.education)
Same for leaving a school