### PR TITLE
Removed use of django.conf.urls.patterns()

### DIFF
--- a/portal/urls.py
+++ b/portal/urls.py
@@ -34,7 +34,7 @@
 # copyright notice and these terms. You must not misrepresent the origins of this
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from django.core.urlresolvers import reverse_lazy
 from django.views.generic.base import TemplateView
 from django.views.generic import RedirectView
@@ -81,8 +81,7 @@ two_factor_patterns = [
 ]
 
 
-urlpatterns = patterns(
-    '',
+urlpatterns = [
     url(r'^aimmo/', include('players.urls')),
     url(r'^favicon\.ico$', RedirectView.as_view(url='/static/portal/img/favicon.ico', permanent=True)),
 
@@ -164,4 +163,4 @@ urlpatterns = patterns(
         url(r'^lastconnectedsince/(?P<year>\d{4})/(?P<month>\d{2})/(?P<day>\d{2})/$', last_connected_since, name="last-connected-since"),
         url(r'^userspercountry/(?P<country>(AF|AX|AL|DZ|AS|AD|AO|AI|AQ|AG|AR|AM|AW|AU|AT|AZ|BS|BH|BD|BB|BY|BE|BZ|BJ|BM|BT|BO|BQ|BA|BW|BV|BR|IO|BN|BG|BF|BI|KH|CM|CA|CV|KY|CF|TD|CL|CN|CX|CC|CO|KM|CG|CD|CK|CR|CI|HR|CU|CW|CY|CZ|DK|DJ|DM|DO|EC|EG|SV|GQ|ER|EE|ET|FK|FO|FJ|FI|FR|GF|PF|TF|GA|GM|GE|DE|GH|GI|GR|GL|GD|GP|GU|GT|GG|GN|GW|GY|HT|HM|VA|HN|HK|HU|IS|IN|ID|IR|IQ|IE|IM|IL|IT|JM|JP|JE|JO|KZ|KE|KI|KP|KR|KW|KG|LA|LV|LB|LS|LR|LY|LI|LT|LU|MO|MK|MG|MW|MY|MV|ML|MT|MH|MQ|MR|MU|YT|MX|FM|MD|MC|MN|ME|MS|MA|MZ|MM|NA|NR|NP|NL|NC|NZ|NI|NE|NG|NU|NF|MP|NO|OM|PK|PW|PS|PA|PG|PY|PE|PH|PN|PL|PT|PR|QA|RE|RO|RU|RW|BL|SH|KN|LC|MF|PM|VC|WS|SM|ST|SA|SN|RS|SC|SL|SG|SX|SK|SI|SB|SO|ZA|GS|SS|ES|LK|SD|SR|SJ|SZ|SE|CH|SY|TW|TJ|TZ|TH|TL|TG|TK|TO|TT|TN|TR|TM|TC|TV|UG|UA|AE|GB|US|UM|UY|UZ|VU|VE|VN|VG|VI|WF|EH|YE|ZM|ZW))/$', number_users_per_country, name="number_users_per_country"),
     ])),
-)
+]

--- a/reports/urls.py
+++ b/reports/urls.py
@@ -34,7 +34,7 @@
 # copyright notice and these terms. You must not misrepresent the origins of this
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 from rest_framework import status
 from django.http import HttpResponse
 from models import Event
@@ -82,6 +82,5 @@ except ImportError:
     def test_panda(request):
         return HttpResponse("The Panda is not loaded", content_type='text/plain', status=status.HTTP_200_OK)
 
-urlpatterns = patterns('',
-                       url(r'^event$', event, name='post_event'),
-                       url(r'^test$', test_panda, name='test_panda'),)
+urlpatterns = [url(r'^event$', event, name='post_event'),
+                url(r'^test$', test_panda, name='test_panda')]


### PR DESCRIPTION
RemovedInDjango110Warning: django.conf.urls.patterns() is deprecated and will be removed in Django 1.10. Update your urlpatterns to be a list of django.conf.urls.url() instances instead.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/738)
<!-- Reviewable:end -->
