### PR TITLE
Login buttons wrap properly always

### DIFF
--- a/portal/static/portal/sass/partials/_header.scss
+++ b/portal/static/portal/sass/partials/_header.scss
@@ -6,6 +6,8 @@
 }
 
 .menu__right-side {
+  width: fit-content;
+
   .dropdown {
     width: 90%;
   }


### PR DESCRIPTION
Added the fit-content value to the menu's right side's width attribute, that way the Register and Log In buttons never need to wrap on two lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/868)
<!-- Reviewable:end -->
