### PR TITLE
Deleted instruction to hide menu

### DIFF
--- a/portal/static/portal/js/sticky_subnav.js
+++ b/portal/static/portal/js/sticky_subnav.js
@@ -34,7 +34,6 @@ function toggleStickySubnav(scrollToTop) {
         if (currentScroll >= scrollToTop) {
             if (!$('.sticky-subnav').hasClass("sub-nav--fixed")) {
                 $('.sticky-subnav').addClass('sub-nav--fixed');
-                $('.menu').addClass('hide');
             }
             if (!$('#sticky-warning').hasClass('sub-nav--warning--fixed')) {
                 $('#sticky-warning').addClass('sub-nav--warning--fixed');


### PR DESCRIPTION
It was unnecessary because when the sub-navigation bar sticks to the top of the screen the menu gets overlapped automatically. When it's a warning bar, both the bar and the menu remain at the top of the screen.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/874)
<!-- Reviewable:end -->
