### PR TITLE
Caches materials page

### DIFF
--- a/portal/templates/portal/teach/materials.html
+++ b/portal/templates/portal/teach/materials.html
@@ -2,6 +2,7 @@
 {% load staticfiles %}
 {% load app_tags %}
 {% load table_tags %}
+{% load cache %}
 
 {% block materials %}
 <a href="{% url 'teaching_resources' %}" class="button--menu button--menu--secondary button--menu--enabled button--menu--teacher--active">Teaching Resources</a>
@@ -40,6 +41,7 @@
 {% block content %}
 {{ block.super }}
 
+{% cache 3600 fragment-materials-page %}
 <div id="materials_page"></div>
 
 <div id="user_guide">
@@ -290,5 +292,5 @@
     });
 </script>
 
-
+{% endcache %}
 {% endblock content %}


### PR DESCRIPTION
Adds the materials page in a cache block which caches the page for an hour.

Django documentation: https://docs.djangoproject.com/en/2.1/topics/cache/#s-template-fragment-caching

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/896)
<!-- Reviewable:end -->
