### PR TITLE
fix: z-indexes of top menu, dropdown and subnavs

### DIFF
--- a/portal/static/portal/sass/modules/_levels.scss
+++ b/portal/static/portal/sass/modules/_levels.scss
@@ -1,2 +1,2 @@
 $hover-content-level: 100;
-$nav-bar-level: 200;
+$nav-bar-level: 201;

--- a/portal/static/portal/sass/partials/_images-backgrounds.scss
+++ b/portal/static/portal/sass/partials/_images-backgrounds.scss
@@ -69,7 +69,7 @@ img {
   content: url('../img/logo_c4l_hexa.png');
   position: fixed;
   top: 10px;
-  z-index: $nav-bar-level + 1;
+  z-index: $nav-bar-level + 2;
 }
 
 .glyphicon {
@@ -111,7 +111,7 @@ img {
     content: url('../img/logo_c4l_hexa.png');
     position: fixed;
     top: 10px;
-    z-index: $nav-bar-level + 1;
+    z-index: $nav-bar-level + 2;
   }
 
   .logo-horizontal {

--- a/portal/static/portal/sass/partials/_subnavs.scss
+++ b/portal/static/portal/sass/partials/_subnavs.scss
@@ -39,7 +39,7 @@
   position: fixed;
   top: 0;
   width: 100%;
-  z-index: $nav-bar-level - 1;
+  z-index: $nav-bar-level + 1;
 }
 
 .sub-nav--warning {

--- a/portal/static/portal/sass/partials/_subnavs.scss
+++ b/portal/static/portal/sass/partials/_subnavs.scss
@@ -8,7 +8,7 @@
   justify-content: center;
   text-align: center;
   width: 100%;
-  z-index: $nav-bar-level;
+  z-index: $nav-bar-level - 1;
 
   .button--regular {
     @include _margin(0px, 16px, 0px, 16px);
@@ -39,6 +39,7 @@
   position: fixed;
   top: 0;
   width: 100%;
+  z-index: $nav-bar-level - 1;
 }
 
 .sub-nav--warning {
@@ -65,6 +66,7 @@
   position: fixed;
   top: 80px;
   width: 100%;
+  z-index: $nav-bar-level - 1;
 }
 
 .sub-nav--message--fixed {
@@ -72,7 +74,7 @@
   position: fixed;
   top: 80px;
   width: 100%;
-  z-index: $nav-bar-level;
+  z-index: $nav-bar-level - 1;
 }
 
 .sub-nav--filler {

--- a/portal/templates/portal/base.html
+++ b/portal/templates/portal/base.html
@@ -362,7 +362,7 @@
         var scroll = $(window).scrollTop();
         if (scroll > 0 && $('.dropdown').hasClass('open')) {
             $('.dropdown').removeClass('open');
-            $('.button--dropdown').attr("aria-expanded","false");
+            $('.button--dropdown').attr("aria-expanded", "false");
         }
     });
 

--- a/portal/templates/portal/base.html
+++ b/portal/templates/portal/base.html
@@ -358,6 +358,14 @@
         target.value = refURL;
     });
 
+    $(window).on('scroll', function() {
+        var scroll = $(window).scrollTop();
+        if ((scroll > 0) && ($('.dropdown').hasClass('open'))) {
+            $('.dropdown').removeClass('open');
+            $('.button--dropdown').attr("aria-expanded","false");
+        }
+    });
+
 </script>
 {% endblock scripts %}
 

--- a/portal/templates/portal/base.html
+++ b/portal/templates/portal/base.html
@@ -360,7 +360,7 @@
 
     $(window).on('scroll', function() {
         var scroll = $(window).scrollTop();
-        if ((scroll > 0) && ($('.dropdown').hasClass('open'))) {
+        if (scroll > 0 && $('.dropdown').hasClass('open')) {
             $('.dropdown').removeClass('open');
             $('.button--dropdown').attr("aria-expanded","false");
         }


### PR DESCRIPTION
Changed z-indexes so that the elements are properly placed and the dropdown menu gets closed when the user scrolls so it doesn't become unreachable on Rapid Router's page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/928)
<!-- Reviewable:end -->
