### PR TITLE
fix(test_settings.py): Point to example project static root so Selenium tests run using compiled styles

### DIFF
--- a/test_settings.py
+++ b/test_settings.py
@@ -39,7 +39,7 @@ TEMPLATES = [
 INSTALLED_APPS = ['portal']
 PIPELINE_ENABLED = False
 ROOT_URLCONF = 'django_autoconfig.autourlconf'
-STATIC_ROOT = 'portal/static'
+STATIC_ROOT = 'example_project/example_project/static'
 SECRET_KEY = 'bad_test_secret'
 
 from django_autoconfig.autoconfig import configure_settings


### PR DESCRIPTION
So far the static root constant in `test_settings.py` pointed to `portal/static`. This was fine before since this was where the old `styles.css` file was stored, and that was where the project got the final styles from.
Ever since the redesign however, and the use of Sass instead of CSS, the Sass files took over the `portal/static` directory and `styles.css` is now compiled automatically in `example_project/example_project/static`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/929)
<!-- Reviewable:end -->
