### PR TITLE
fix: link points to right PDF and wording updated

### DIFF
--- a/portal/templates/portal/teach.html
+++ b/portal/templates/portal/teach.html
@@ -69,7 +69,7 @@
                         Built on &lsquo;Blockly&rsquo;, an easy-to-use visual programming language that's similar to Scratch, Rapid Router enables teachers to monitor and manage
                         individual pupil progress and identify where more support is required.</p>
 
-                    <p><a href="{{ 'general_resources/introduction_to_coding.pdf'|cloud_storage }}">See how the app relates to both Key Stage 1 and Lower Key Stage 2 of the computer science strand here</a>.</p>
+                    <p><a href="{{ 'user_guide/introduction_to_coding.pdf'|cloud_storage }}">See how the app relates to Key Stages 1, 2 and 3 of the computer science strand here</a>.</p>
                 </div>
                 <section class="col-sm-6">
                     <a href="https://www.youtube.com/embed/xP-U-MJLk-g?rel=0&amp;autoplay=1" class="youtube">


### PR DESCRIPTION
Link now points to the updated PDF and the description includes KS 1, 2 and 3