### PR TITLE
fix: Remove context_instance leftover from Django 1.10 Upgrade

### DIFF
--- a/portal/views/teacher/solutions_level_selector.py
+++ b/portal/views/teacher/solutions_level_selector.py
@@ -127,7 +127,8 @@ def levels(request):
 
     episode_data = fetch_episode_data(app_settings.EARLY_ACCESS_FUNCTION(request))
 
-    context = RequestContext(request, {"episodeData": episode_data})
     return render(
-        request, "portal/teach/teacher_level_solutions.html", context_instance=context
+        request,
+        "portal/teach/teacher_level_solutions.html",
+        {"episodeData": episode_data},
     )


### PR DESCRIPTION
This fixes an issue we found during deployment

Signed-off-by: Niket Shah <masterniket@gmail.com>