### PR TITLE
fix: game table column size

### DIFF
--- a/portal/templates/portal/partials/aimmo_games_table.html
+++ b/portal/templates/portal/partials/aimmo_games_table.html
@@ -5,7 +5,7 @@
 {% endblock scripts %}
 {% if open_play_games %}
     {% include "portal/partials/popup.html" %}
-    <div class="col-sm-8 col-center">
+    <div class="col-sm-10 col-center">
         <table id="games-table" class="games-table header-primary data-primary">
             <tr class="games-table__header">
                 <th class="cell-left">


### PR DESCRIPTION
At some point the button font size on the AI:MMO game table was changed and the table column layout wasn't updated to reflect that for screen sizes of over 1200px of width. The change is now implemented

Screenshot:
<img width="649" alt="Screenshot 2019-06-07 at 09 22 26" src="https://user-images.githubusercontent.com/30693435/59090945-1cf2e400-8906-11e9-8bf3-e67c2993a10e.png">
