### PR TITLE
fix: Got rid of pink flash 

### DIFF
--- a/portal/static/portal/sass/partials/_forms.scss
+++ b/portal/static/portal/sass/partials/_forms.scss
@@ -124,6 +124,10 @@ form {
   background-color: $color-background-play-indep;
 }
 
+#independent-student-login {
+  display: none;
+}
+
 .form__register-checkbox {
   display: flex;
   align-items: center;


### PR DESCRIPTION
**Issue**
When clicking login there is a quick pink flash at the bottom of the screen. This is connected to the Independent Student Login section that was being hidden in that split second of a frame. Looking closer, there is also another flash that is white.
**Solution**
For the pink flash, I went to the css code for the login of the Independent Student and just hid it so that it doesn't appear when loading in. The white flash is something that I have not found a solution to however. It seems to just be a rendering problem that I do not how to change. 