### PR TITLE
fix: permission error on staging

### DIFF
--- a/portal/autoconfig.py
+++ b/portal/autoconfig.py
@@ -136,6 +136,7 @@ SETTINGS = {
     "RAPID_ROUTER_EARLY_ACCESS_FUNCTION_NAME": "portal.beta.has_beta_access",
     "PREVIEW_USER_AIMMO_DECORATOR": "portal.permissions.preview_user",
     "IS_PREVIEW_USER_AIMMO_CLASS": "portal.permissions.IsPreviewUser",
+    "CAN_DELETE_GAME_CLASS": "portal.permissions.CanDeleteGame",
     "IS_TEACHER_CLASS": "portal.permissions.IsTeacher",
     "USERS_FOR_NEW_AIMMO_GAME": "portal.aimmo_game.get_users_for_new_game",
 }

--- a/portal/autoconfig.py
+++ b/portal/autoconfig.py
@@ -135,9 +135,7 @@ SETTINGS = {
     },
     "RAPID_ROUTER_EARLY_ACCESS_FUNCTION_NAME": "portal.beta.has_beta_access",
     "PREVIEW_USER_AIMMO_DECORATOR": "portal.permissions.preview_user",
-    "IS_PREVIEW_USER_AIMMO_CLASS": "portal.permissions.IsPreviewUser",
     "CAN_DELETE_GAME_CLASS": "portal.permissions.CanDeleteGame",
-    "IS_TEACHER_CLASS": "portal.permissions.IsTeacher",
     "USERS_FOR_NEW_AIMMO_GAME": "portal.aimmo_game.get_users_for_new_game",
 }
 

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -107,11 +107,7 @@ class IsPreviewUser(permissions.BasePermission):
     def has_permission(self, request, view):
         u = request.user
         try:
-            print(
-                "OHMYGOD IT GOT HERE WHICH MEANS WE STILL DON'T KNOW WHAT'S WRONG LMAO"
-            )
-            if u.userprofile.preview_user:
-                print("AND WE HAS PREVIEW USER")
+            print(u.userprofile)
             return u.userprofile.preview_user and has_completed_auth_setup(u)
         except AttributeError:
             return False

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -103,24 +103,6 @@ def preview_user(view_func):
     return wrapped
 
 
-class IsPreviewUser(permissions.BasePermission):
-    def has_permission(self, request, view):
-        u = request.user
-        try:
-            return u.userprofile.preview_user and has_completed_auth_setup(u)
-        except AttributeError:
-            return False
-
-
-class IsTeacher(permissions.BasePermission):
-    def has_permission(self, request, view):
-        u = request.user
-        try:
-            return u.userprofile.teacher and has_completed_auth_setup(u)
-        except AttributeError:
-            return False
-
-
 class CanDeleteGame(permissions.BasePermission):
     def has_permission(self, request, view):
         u = request.user

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -107,7 +107,7 @@ class IsPreviewUser(permissions.BasePermission):
     def has_permission(self, request, view):
         u = request.user
         try:
-            return u.userprofile and has_completed_auth_setup(u)
+            return u.userprofile.preview_user and has_completed_auth_setup(u)
         except AttributeError:
             return False
 
@@ -117,5 +117,18 @@ class IsTeacher(permissions.BasePermission):
         u = request.user
         try:
             return u.userprofile.teacher and has_completed_auth_setup(u)
+        except AttributeError:
+            return False
+
+
+class CanDeleteGame(permissions.BasePermission):
+    def has_permission(self, request, view):
+        u = request.user
+        try:
+            return (
+                u.userprofile.teacher
+                and u.userprofile.preview_user
+                and has_completed_auth_setup(u)
+            )
         except AttributeError:
             return False

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -107,6 +107,9 @@ class IsPreviewUser(permissions.BasePermission):
     def has_permission(self, request, view):
         u = request.user
         try:
+            print(
+                "OHMYGOD IT GOT HERE WHICH MEANS WE STILL DON'T KNOW WHAT'S WRONG LMAO"
+            )
             return u.userprofile.preview_user and has_completed_auth_setup(u)
         except AttributeError:
             return False

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -107,7 +107,7 @@ class IsPreviewUser(permissions.BasePermission):
     def has_permission(self, request, view):
         u = request.user
         try:
-            return u.userprofile.preview_user and has_completed_auth_setup(u)
+            return u.userprofile and has_completed_auth_setup(u)
         except AttributeError:
             return False
 

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -110,6 +110,7 @@ class IsPreviewUser(permissions.BasePermission):
             print(
                 "OHMYGOD IT GOT HERE WHICH MEANS WE STILL DON'T KNOW WHAT'S WRONG LMAO"
             )
+            print(u.userprofile.preview_user)
             return u.userprofile.preview_user and has_completed_auth_setup(u)
         except AttributeError:
             return False

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -110,7 +110,8 @@ class IsPreviewUser(permissions.BasePermission):
             print(
                 "OHMYGOD IT GOT HERE WHICH MEANS WE STILL DON'T KNOW WHAT'S WRONG LMAO"
             )
-            print(u.userprofile.preview_user)
+            if u.userprofile.preview_user:
+                print("AND WE HAS PREVIEW USER")
             return u.userprofile.preview_user and has_completed_auth_setup(u)
         except AttributeError:
             return False

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -43,7 +43,7 @@ from rest_framework import permissions
 
 
 def has_completed_auth_setup(u):
-    return not using_two_factor(u) or (u.is_verified() and using_two_factor(u))
+    return (not using_two_factor(u)) or (u.is_verified() and using_two_factor(u))
 
 
 def logged_in_as_teacher(u):

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -107,9 +107,9 @@ class IsPreviewUser(permissions.BasePermission):
     def has_permission(self, request, view):
         u = request.user
         try:
-            print(u.userprofile)
             return u.userprofile.preview_user and has_completed_auth_setup(u)
         except AttributeError:
+            print(u.userprofile)
             return False
 
 

--- a/portal/permissions.py
+++ b/portal/permissions.py
@@ -109,7 +109,6 @@ class IsPreviewUser(permissions.BasePermission):
         try:
             return u.userprofile.preview_user and has_completed_auth_setup(u)
         except AttributeError:
-            print(u.userprofile)
             return False
 
 

--- a/portal/static/portal/js/delete_aimmo_game.js
+++ b/portal/static/portal/js/delete_aimmo_game.js
@@ -58,9 +58,6 @@ function deleteGame() {
         type: 'delete',
         headers: {
             "X-CSRFToken": $('input[name=csrfmiddlewaretoken]').val()
-        },
-        xhrFields: {
-            withCredentials: true
         }
     })
     hidePopupConfirmation();

--- a/portal/static/portal/js/delete_aimmo_game.js
+++ b/portal/static/portal/js/delete_aimmo_game.js
@@ -58,6 +58,9 @@ function deleteGame() {
         type: 'delete',
         headers: {
             "X-CSRFToken": $('input[name=csrfmiddlewaretoken]').val()
+        },
+        xhrFields: {
+            withCredentials: true
         }
     })
     hidePopupConfirmation();

--- a/portal/static/portal/js/delete_aimmo_game.js
+++ b/portal/static/portal/js/delete_aimmo_game.js
@@ -59,9 +59,6 @@ function deleteGame() {
         data: { _method: 'delete' },
         headers: {
             "X-CSRFToken": $('input[name=csrfmiddlewaretoken]').val()
-        },
-        error: function (data) {
-            console.log('Error:', data);
         }
     })
     hidePopupConfirmation();

--- a/portal/static/portal/js/delete_aimmo_game.js
+++ b/portal/static/portal/js/delete_aimmo_game.js
@@ -58,8 +58,7 @@ function deleteGame() {
         type: 'delete',
         headers: {
             "X-CSRFToken": $('input[name=csrfmiddlewaretoken]').val()
-        },
-        xhrFields: { withCredentials: true }
+        }
     })
     hidePopupConfirmation();
     document.location.reload(true);

--- a/portal/static/portal/js/delete_aimmo_game.js
+++ b/portal/static/portal/js/delete_aimmo_game.js
@@ -58,7 +58,8 @@ function deleteGame() {
         type: 'delete',
         headers: {
             "X-CSRFToken": $('input[name=csrfmiddlewaretoken]').val()
-        }
+        },
+        xhrFields: { withCredentials: true }
     })
     hidePopupConfirmation();
     document.location.reload(true);

--- a/portal/static/portal/js/delete_aimmo_game.js
+++ b/portal/static/portal/js/delete_aimmo_game.js
@@ -55,9 +55,13 @@ function deleteGame() {
     var game_id = $("#popup").attr("data-game-id");
     $.ajax({
         url: '/aimmo/api/games/' + game_id + '/',
-        type: 'delete',
+        type: 'DELETE',
+        data: { _method: 'delete' },
         headers: {
             "X-CSRFToken": $('input[name=csrfmiddlewaretoken]').val()
+        },
+        error: function (data) {
+            console.log('Error:', data);
         }
     })
     hidePopupConfirmation();


### PR DESCRIPTION
Having two permission classes checking the same request seemed to somehow alter the data and make the delete request user Anonymous (IsTeacher and IsPreviewUser permissions). It's related to Django's authentication, and it might have been fixed when the session authentication was added to the game view on the AI:MMO project, but having one unified permission to check if a user can delete a game makes the code more compact.

The reason for having two separate permission classes before was the fact that AI:MMO didn't make the distinction between safe methods and unsafe methods, and it could clash with the fact that not all the users who have access to the games are teachers. Since AI:MMO now makes the distinction, this shouldn't be needed anymore.