### PR TITLE
fix: Fixed social media spacing

### DIFF
--- a/portal/static/portal/sass/partials/_footer.scss
+++ b/portal/static/portal/sass/partials/_footer.scss
@@ -51,6 +51,8 @@
   }
 
   .social-media {
+    align-items: center;
+    display: flex;
     margin-top: 10px;
   }
 


### PR DESCRIPTION
Made social media icons inline with each other through a few css tweaks. All that was added was the two lines of code: display: flex; align-items: center. 