### PR TITLE
fix: removed password requirement for create school

### DIFF
--- a/portal/forms/organisation.py
+++ b/portal/forms/organisation.py
@@ -45,6 +45,7 @@ from django.core.exceptions import ObjectDoesNotExist
 class OrganisationForm(forms.ModelForm):
 
     class Meta:
+        
         model = School
         fields = ["name", "postcode", "country"]
         labels = {

--- a/portal/forms/organisation.py
+++ b/portal/forms/organisation.py
@@ -44,7 +44,6 @@ from django.core.exceptions import ObjectDoesNotExist
 
 class OrganisationForm(forms.ModelForm):
 
-
     class Meta:
         model = School
         fields = ["name", "postcode", "country"]

--- a/portal/forms/organisation.py
+++ b/portal/forms/organisation.py
@@ -71,8 +71,6 @@ class OrganisationForm(forms.ModelForm):
         self.current_school = kwargs.pop("current_school", None)
         super(OrganisationForm, self).__init__(*args, **kwargs)
         self.fields["postcode"].strip = False
-        if self.current_school:
-            del self.fields["current_password"]
 
     def clean(self):
         name = self.cleaned_data.get("name", None)

--- a/portal/forms/organisation.py
+++ b/portal/forms/organisation.py
@@ -45,7 +45,7 @@ from django.core.exceptions import ObjectDoesNotExist
 class OrganisationForm(forms.ModelForm):
 
     class Meta:
-        
+
         model = School
         fields = ["name", "postcode", "country"]
         labels = {

--- a/portal/forms/organisation.py
+++ b/portal/forms/organisation.py
@@ -44,12 +44,6 @@ from django.core.exceptions import ObjectDoesNotExist
 
 class OrganisationForm(forms.ModelForm):
 
-    current_password = forms.CharField(
-        label="Enter your password",
-        widget=forms.PasswordInput(
-            attrs={"autocomplete": "new-password", "placeholder": "Your Password"}
-        ),
-    )
 
     class Meta:
         model = School
@@ -108,11 +102,6 @@ class OrganisationForm(forms.ModelForm):
                 raise forms.ValidationError("Please enter a valid postcode or ZIP code")
 
         return postcode
-
-    def clean_current_password(self):
-        current_password = self.cleaned_data.get("current_password", None)
-        if not self.user.check_password(current_password):
-            raise forms.ValidationError("Your password was incorrect")
 
 
 class OrganisationJoinForm(forms.Form):

--- a/portal/tests/pageObjects/portal/teach/onboarding_organisation_page.py
+++ b/portal/tests/pageObjects/portal/teach/onboarding_organisation_page.py
@@ -74,7 +74,6 @@ class OnboardingOrganisationPage(TeachBasePage):
     def _create_organisation(self, name, password, postcode, country):
         self.browser.find_element_by_id("id_name").send_keys(name)
         self.browser.find_element_by_id("id_postcode").send_keys(postcode)
-        self.browser.find_element_by_id("id_current_password").send_keys(password)
         country_element = self.browser.find_element_by_id("id_country")
         select = Select(country_element)
         select.select_by_value(country)


### PR DESCRIPTION
**Problem**
The "create/join school" required a password for the teacher to input. This is not needed.

**Solution**
We decided to take out the password definition under the OrganisationForm class and the definition for the clean password. This removed the requirement to input your password.