### PR TITLE
fix: created stub for future library

### DIFF
--- a/example_project/example_project/settings.py
+++ b/example_project/example_project/settings.py
@@ -34,57 +34,54 @@
 # copyright notice and these terms. You must not misrepresent the origins of this
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
-'''Django settings for example_project project.'''
+"""Django settings for example_project project."""
 import os
 
 DEBUG = True
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'OPTIONS': {
-            'debug': DEBUG,
-        },
-    },
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "OPTIONS": {"debug": DEBUG},
+    }
 ]
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3', # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
-        'NAME': os.path.join(os.path.abspath(os.path.dirname(__file__)),'db.sqlite3'),# Or path to database file if using sqlite3.
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",  # Add 'postgresql_psycopg2', 'mysql', 'sqlite3' or 'oracle'.
+        "NAME": os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), "db.sqlite3"
+        ),  # Or path to database file if using sqlite3.
     }
 }
 
 USE_I18N = True
 USE_L10N = True
-TIME_ZONE = 'Europe/London'
+TIME_ZONE = "Europe/London"
 
-LANGUAGE_CODE = 'en-gb'
-STATIC_ROOT = os.path.join(os.path.dirname(__file__), 'static')
-STATIC_URL = '/static/'
-MEDIA_ROOT = os.path.join(STATIC_ROOT, 'email_media/')
-SECRET_KEY = 'not-a-secret'
+LANGUAGE_CODE = "en-gb"
+STATIC_ROOT = os.path.join(os.path.dirname(__file__), "static")
+STATIC_URL = "/static/"
+MEDIA_ROOT = os.path.join(STATIC_ROOT, "email_media/")
+SECRET_KEY = "not-a-secret"
 
-ROOT_URLCONF = 'example_project.urls'
+ROOT_URLCONF = "example_project.urls"
 
-WSGI_APPLICATION = 'example_project.wsgi.application'
+WSGI_APPLICATION = "example_project.wsgi.application"
 
-LOGIN_REDIRECT_URL = '/portal/teach/dashboard/'
+LOGIN_REDIRECT_URL = "/teach/dashboard/"
 
-EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-INSTALLED_APPS = (
-    'portal',
-    'captcha',
-    'django_forms_bootstrap',
-)
+INSTALLED_APPS = ("portal", "captcha", "django_forms_bootstrap")
 
 PIPELINE_ENABLED = False
 
 try:
-    from example_project.local_settings import * # pylint: disable=E0611
+    from example_project.local_settings import *  # pylint: disable=E0611
 except ImportError:
     pass
 
 from django_autoconfig import autoconfig
+
 autoconfig.configure_settings(globals())

--- a/portal/templatetags/future.py
+++ b/portal/templatetags/future.py
@@ -2,9 +2,3 @@ from django.template import Library
 from django.template.defaulttags import cycle as cycle_original
 
 register = Library()
-
-
-@register.tag
-def cycle(*args, **kwargs):
-    """ A stub to get SortableTabularInline to work """
-    return cycle_original(*args, **kwargs)

--- a/portal/templatetags/future.py
+++ b/portal/templatetags/future.py
@@ -1,0 +1,10 @@
+from django.template import Library
+from django.template.defaulttags import cycle as cycle_original
+
+register = Library()
+
+
+@register.tag
+def cycle(*args, **kwargs):
+    """ A stub to get SortableTabularInline to work """
+    return cycle_original(*args, **kwargs)

--- a/portal/templatetags/future.py
+++ b/portal/templatetags/future.py
@@ -1,3 +1,7 @@
+"""
+A stub for the future tag library to address the registered tag issue
+that arises with Django 1.10
+"""
 from django.template import Library
 from django.template.defaulttags import cycle as cycle_original
 


### PR DESCRIPTION
When upgrading to Django 1.10, an issue arose with the 2FA configuration that went undetected. A stub for the future tag library was created based on the recommendation [here](https://github.com/alsoicode/django-admin-sortable/issues/151#issuecomment-237205015).