### PR TITLE
fix: 2FA url broken

### DIFF
--- a/portal/autoconfig.py
+++ b/portal/autoconfig.py
@@ -125,6 +125,7 @@ SETTINGS = {
             },
         }
     ],
+    "LOGIN_REDIRECT_URL": "/teach/dashboard/",
     "CODEFORLIFE_WEBSITE": "www.codeforlife.education",
     "CLOUD_STORAGE_PREFIX": "//storage.googleapis.com/codeforlife-assets/",
     "LOGGING": {


### PR DESCRIPTION
The redirect url settings weren't being properly set up, only in the example project.