### PR TITLE
fix: changed regex to allow spaces

### DIFF
--- a/portal/static/portal/js/join_create_game_toggle.js
+++ b/portal/static/portal/js/join_create_game_toggle.js
@@ -63,7 +63,7 @@ $(document).ready(function () {
         if (!game_name_input.val() || game_name_input.val() === "") {
             showInputError("Give your new game a name...");
         }
-        var exp = /^[\w-]+$/;
+        var exp = /^[\w- ]+$/;
         if (!exp.test(game_name_input.val())) {
             showInputError("Name cannot contain special characters.");
         }


### PR DESCRIPTION
The game creation form had been changed to sanitise input, but the regular expression added didn't allow spaces between alphanumeric characters. This has been fixed now, while special characters are still not allowed.