### PR TITLE
fix: remove scoreboard button

### DIFF
--- a/portal/templates/portal/base.html
+++ b/portal/templates/portal/base.html
@@ -136,6 +136,7 @@
                                 <a href="{% url 'aimmo' %}"><small>AI:MMO</small></a>
                             </div>
                         </div>
+                        {% if user|is_logged_in_as_school_user %}
                         <div class="dropdown">
                             <a href="{% url 'scoreboard' %}" id="student_scoreboards_button"
                                class="button--menu button--menu--secondary button--menu--enabled">View Scoreboards</a>
@@ -143,6 +144,7 @@
                                 <a href="{% url 'scoreboard' %}"><small>Rapid Router</small></a>
                             </div>
                         </div>
+                        {% endif %}
                         {% if not user.new_student.class_field %}
                             <a href="{% url 'student_join_organisation' %}" id="student_join_school_button"
                                class="button--menu button--menu--secondary button--menu--enabled">Join a school</a>

--- a/portal/templates/portal/base_old.html
+++ b/portal/templates/portal/base_old.html
@@ -129,11 +129,11 @@
                 {% endif %}
                 {% endblock leftMenuButtons %}
             </div>
-            <div class="menu__right-side col-sm-2">
+            <div class="menu__right-side col-sm-3">
                 {% block rightMenuButtons %}
                 {% if user|is_logged_in %}
                 <div class="dropdown">
-                    <button id="logout_menu" class="button button--regular button--secondary button--secondary--dark logout"
+                    <button id="logout_menu" class="button button--regular button--secondary button--secondary--dark button--dropdown logout"
                             data-toggle="dropdown">
                         <div class="dropdown__text">{{ user|make_into_username }}</div>
                         <div class="glyphicon glyphicon-user"></div></button>

--- a/portal/templates/portal/play/student_details.html
+++ b/portal/templates/portal/play/student_details.html
@@ -11,6 +11,7 @@
         <a href="{% url 'aimmo' %}"><small>AI:MMO</small></a>
     </div>
 </div>
+{% if user|is_logged_in_as_school_user %}
 <div class="dropdown">
     <a href="{% url 'scoreboard' %}" id="student_scoreboards_button"
        class="button--menu button--menu--secondary button--menu--enabled">View Scoreboards</a>
@@ -18,6 +19,7 @@
         <a href="{% url 'scoreboard' %}"><small>Rapid Router</small></a>
     </div>
 </div>
+{% endif %}
 {% if not user.new_student.class_field %}
 <a href="{% url 'student_join_organisation' %}" id="student_join_school_button"
    class="button--menu button--menu--secondary button--menu--enabled">Join a school</a>
@@ -49,7 +51,9 @@
             Using Blockly, you can advance through the levels to become an Ocado delivery hero.</p>
         <div>
             <p><a href="{% url 'play' %}">Learn more about Rapid Router</a></p>
+            {% if user|is_logged_in_as_school_user %}
             <p><a href="{% url 'scoreboard' %}">View my score</a></p>
+            {% endif %}
         </div>
         {% if user.new_student.class_field and user|is_preview_user %}
             <section>

--- a/portal/templates/portal/play/student_edit_account.html
+++ b/portal/templates/portal/play/student_edit_account.html
@@ -1,5 +1,6 @@
 {% extends 'portal/base_old.html' %}
 {% load static %}
+{% load app_tags %}
 
 {% block studentButtons %}
 <div class="dropdown">
@@ -10,6 +11,7 @@
         <a href="{% url 'aimmo' %}"><small>AI:MMO</small></a>
     </div>
 </div>
+{% if user|is_logged_in_as_school_user %}
 <div class="dropdown">
     <a href="{% url 'scoreboard' %}" id="student_scoreboards_button"
        class="button--menu button--menu--secondary button--menu--enabled">View Scoreboards</a>
@@ -17,6 +19,7 @@
         <a href="{% url 'scoreboard' %}"><small>Rapid Router</small></a>
     </div>
 </div>
+{% endif %}
 {% if not user.new_student.class_field %}
 <a href="{% url 'student_join_organisation' %}" id="student_join_school_button"
    class="button--menu button--menu--secondary button--menu--enabled">Join a school</a>

--- a/portal/templates/portal/play/student_join_organisation.html
+++ b/portal/templates/portal/play/student_join_organisation.html
@@ -1,5 +1,6 @@
 {% extends 'portal/base_old.html' %}
 {% load static %}
+{% load app_tags %}
 
 {% block studentButtons %}
 <div class="dropdown">
@@ -10,6 +11,7 @@
         <a href="{% url 'aimmo' %}"><small>AI:MMO</small></a>
     </div>
 </div>
+{% if user|is_logged_in_as_school_user %}
 <div class="dropdown">
     <a href="{% url 'scoreboard' %}" id="student_scoreboards_button"
        class="button--menu button--menu--secondary button--menu--enabled">View Scoreboards</a>
@@ -17,6 +19,7 @@
         <a href="{% url 'scoreboard' %}"><small>Rapid Router</small></a>
     </div>
 </div>
+{% endif %}
 {% if not user.new_student.class_field %}
 <a href="{% url 'student_join_organisation' %}" id="student_join_school_button"
    class="button--menu button--menu--secondary button--menu--enabled button--menu--student--active">Join a school</a>


### PR DESCRIPTION
Add conditions to prevent independent students from having access to the `View Scoreboard` button in the navigation bar. (cf #988)

This PR also removes a link to the scoreboard in the details page "more" links block.

I also noticed that the logout button display was broken on the `Join school` and `Change password` pages. I have included the fix in this MR. Let me know if you prefer a separate PR for this.