### PR TITLE
fix: add AI:MMO header button to old base file

### DIFF
--- a/portal/templates/portal/base_old.html
+++ b/portal/templates/portal/base_old.html
@@ -105,12 +105,22 @@
                             {% block rapidRouter %}
                             <a href="{% url 'levels' %}" class="button--menu button--menu--secondary button--menu--enabled">Rapid Router</a>
                             {% endblock rapidRouter %}
+                            {% block aimmo %}
+                                {% if user|is_preview_user %}
+                                    <a href="{% url 'aimmo' %}" id="aimmo_home_button" class="button--menu button--menu--secondary button--menu--enabled">AI:MMO</a>
+                                {% else %}
+                                    <a href="{% url 'play_aimmo' %}" class="button--menu button--menu--secondary button--menu--enabled">AI:MMO</a>
+                                {% endif %}
+                            {% endblock aimmo %}
                             {% block resources %}
                             <a href="{% url 'teaching_resources' %}" class="button--menu button--menu--secondary button--menu--enabled">Teaching Resources</a>
                             {% endblock resources %}
                         {% else %}
                             <a href="{% url 'onboarding-organisation' %}" class="button--menu button--menu--secondary button--menu--enabled">School / Club</a>
                             <a class="button--menu button--menu--secondary button--menu--disabled">Rapid Router</a>
+                            {% if user|is_eligible_for_testing %}
+                            <a class="button--menu button--menu--secondary button--menu--disabled">AI:MMO</a>
+                            {% endif %}
                             <a class="button--menu button--menu--secondary button--menu--disabled">Teaching Resources</a>
                         {% endif %}
                         {% endblock secondaryButtons %}


### PR DESCRIPTION
This PR adds the AI:MMO header link in the old base, making it visible to users even in the non-redesigned pages (including the 2FA pages).