### PR TITLE
fix: updated PDFs links to refer to AIMMO_v2 folder on the cloud

### DIFF
--- a/portal/views/teacher/pdfs.py
+++ b/portal/views/teacher/pdfs.py
@@ -1010,14 +1010,14 @@ PDF_DATA = {
         "title": "KS3_SC1",
         "description": "Student challenge 1: Move your avatar",
         "links": ["AIMMO_challenge_2"],
-        "url": "AIMMO_v1/student_challenges/Intermediate_Python_SC1.pdf",
+        "url": "AIMMO_v2/student_challenges/Intermediate_Python_SC1.pdf",
         "page_origin": "#ks3-challenges",
     },
     "AIMMO_challenge_2": {
         "title": "KS3_SC2",
         "description": "Student challenge 2: Avoid the obstacles",
         "links": ["AIMMO_challenge_1"],
-        "url": "AIMMO_v1/student_challenges/Intermediate_Python_SC2.pdf",
+        "url": "AIMMO_v2/student_challenges/Intermediate_Python_SC2.pdf",
         "page_origin": "#ks3-challenges",
     },
 }

--- a/portal/views/teacher/pdfs.py
+++ b/portal/views/teacher/pdfs.py
@@ -85,7 +85,7 @@ PDF_DATA = {
         "title": "Introduction to AI:MMO",
         "description": "User guide for AI:MMO, the KS3 game.",
         "links": None,
-        "url": "user_guide_v1/AIMMO_User_guide.pdf",
+        "url": "user_guide_v1/AIMMO_User_guide_v2.pdf",
         "page_origin": "#user-guide",
     },
     # ...................KS1 sessions...........#
@@ -978,8 +978,8 @@ PDF_DATA = {
     "AIMMO_session_1": {
         "title": "Sessions 1",
         "description": "Intermediate Python Session 1 — Teacher Guidance",
-        "links": ["AIMMO_cheat_sheet", "AIMMO_indentation", "AIMMO_next_turn"],
-        "url": "AIMMO_v1/sessions/Intermediate_Python_Teacher_S1.pdf",
+        "links": [],
+        "url": "AIMMO_v2/sessions/Intermediate_Python_Teacher_S1.pdf",
         "page_origin": "#ks3-sessions",
     },
     # ...Intermediate Python Resource Sheets...#
@@ -988,21 +988,21 @@ PDF_DATA = {
         "title": "Code Cheat Sheet",
         "description": "To be used to code the AI:MMO game.",
         "links": [],
-        "url": "AIMMO_v1/resource_sheets/AIMMO_cheat_sheet.pdf",
+        "url": "AIMMO_v2/resource_sheets/AIMMO_cheat_sheet.pdf",
         "page_origin": "#ks3-resource-sheets",
     },
     "AIMMO_S1_2": {
         "title": "Indentation — Why it matters",
         "description": "To be used to understand how to use Python to code the AI:MMO game.",
         "links": [],
-        "url": "AIMMO_v1/resource_sheets/Python_Indentation.pdf",
+        "url": "AIMMO_v2/resource_sheets/Python_Indentation.pdf",
         "page_origin": "#ks3-resource-sheets",
     },
     "AIMMO_S1_3": {
         "title": "Understanding the turn-based game",
         "description": "To be used to understand the AI:MMO game.",
         "links": [],
-        "url": "AIMMO_v1/resource_sheets/AIMMO_Next_Turn.pdf",
+        "url": "AIMMO_v2/resource_sheets/AIMMO_Next_Turn.pdf",
         "page_origin": "#ks3-resource-sheets",
     },
     # ...Intermediate Python Challenges...#


### PR DESCRIPTION
Updated challenge PDFs, uploaded them on the cloud storage, changed the respective urls to link to these.

**Challenge 1:**
![Screenshot 2019-07-23 at 15 34 17](https://user-images.githubusercontent.com/30693435/61720914-8bc5b880-ad5f-11e9-8d73-e43f78326b74.png)
![Screenshot 2019-07-23 at 15 34 23](https://user-images.githubusercontent.com/30693435/61720972-a5670000-ad5f-11e9-8ef4-6c1c912a90f0.png)

**Challenge 2:**
![Screenshot 2019-07-23 at 15 34 43](https://user-images.githubusercontent.com/30693435/61721019-bc0d5700-ad5f-11e9-8c25-28522ac048c5.png)
![Screenshot 2019-07-23 at 15 34 35](https://user-images.githubusercontent.com/30693435/61721049-c596bf00-ad5f-11e9-9035-9e2adae6cfa5.png)

