### PR TITLE
fix: AI:MMO link replaced with landing page for non preview users

### DIFF
--- a/portal/templates/portal/base.html
+++ b/portal/templates/portal/base.html
@@ -112,7 +112,7 @@
                                 {% if user|is_preview_user %}
                                     <a href="{% url 'aimmo' %}" id="aimmo_home_button" class="button--menu button--menu--secondary button--menu--enabled">AI:MMO</a>
                                 {% else %}
-                                    <a href="{% url 'aimmo' %}" class="button--menu button--menu--secondary button--menu--enabled">AI:MMO</a>
+                                    <a href="{% url 'play_aimmo' %}" class="button--menu button--menu--secondary button--menu--enabled">AI:MMO</a>
                                 {% endif %}
                             {% endblock aimmo %}
                             {% block materials %}<a id="resources_button" href="{% url 'teaching_resources' %}" class="button--menu button--menu--secondary button--menu--enabled">Teaching Resources</a>{% endblock materials %}


### PR DESCRIPTION
## Background
There is a bug whereby the AI:MMO link in `base.html` links to landing page and not the home page for preview users, if the user is currently on the Rapid Router landing page.

However, the fix for this bug was wrong as it replaced the AI:MMO link for non-preview users. This means that currently, if non-preview users click on the AI:MMO link in the nav bar, it tries to take them to the AI:MMO home page. This raises a 401 as they are not authorised to view this page.

## Description
This PR fixes this problem by essentially reverting the previous PR on this branch. Another PR will shortly follow to fix the original problem.