### PR TITLE
docs: add copywrite requirements to new task template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_task.md
+++ b/.github/ISSUE_TEMPLATE/new_task.md
@@ -12,4 +12,8 @@ about: A template for a new task
 
 
 
+## Copywrite Requirements
+
+
+
 ## Analytics Requirements


### PR DESCRIPTION
Added the "Copywrite Requirements" optional section on GitHub's new task template.