### PR TITLE
ci: make tests run only in PR builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,10 @@ matrix:
       env: SELENIUM_WEBDRIVER=default
   fast_finish: true
 stages:
-  - test
+  - name: test
+    if: tag IS blank AND type IN (pull_request)
   - name: deploy
-    if: branch = master AND (NOT type IN (pull_request))
+    if: branch = master AND NOT type IN (pull_request)
 jobs:
   include:
     - stage: test


### PR DESCRIPTION
## Description
Currently the tests run on PR builds as well as release builds, after the PRs have been merged.
Since each test stage takes around 12 minutes, this slows down the release process by about 25 minutes (since there are two builds happening after merging).
Sometimes the tests also fail because of Selenium timing out, which just stops the release process until someone notices nothing has been deployed.

This PR should fix this since tests will only run in PR builds!