### PR TITLE
fix: typo in our terms of use page

### DIFF
--- a/portal/templates/portal/terms.html
+++ b/portal/templates/portal/terms.html
@@ -94,7 +94,7 @@
     </div>
 
     <div class="background">
-        <h3>Alerting Cofe for Life</h3>
+        <h3>Alerting Code for Life</h3>
         <p>If you see anything on the Code for Life portal which appears to infringe any part of the Terms & Conditions, then please inform us via the <a href="{% url 'help' %}#contact">Contact Us</a> section of this site.</p>
         <p>We do not endorse or take responsibility for the content of any third party sites that link to or from Code for Life.</p>
     </div>


### PR DESCRIPTION
There was a typo in our Terms of Use (a misspelling of Code for Life). This PR fixes that.

Signed-off-by: Niket Shah <masterniket@gmail.com>