### PR TITLE
fix: benefits partial

### DIFF
--- a/portal/static/portal/sass/partials/_images.scss
+++ b/portal/static/portal/sass/partials/_images.scss
@@ -92,6 +92,7 @@ img {
 }
 
 .grid-benefits__image {
+  @include _padding(0px, 0px, 3 * $spacing, 0px);
   justify-self: center;
   align-self: center;
 }

--- a/portal/templates/portal/partials/benefits.html
+++ b/portal/templates/portal/partials/benefits.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 
-<div class="grid-benefits">
+<div class="grid-benefits row col-sm-10 col-lg-8 col-center homepage-info">
     {% if image1 %}
         <img class="grid-benefits__image grid-benefits__image1" src="{% static image1 %}">
     {% endif %}

--- a/portal/templates/portal/partials/benefits.html
+++ b/portal/templates/portal/partials/benefits.html
@@ -1,6 +1,6 @@
 {% load staticfiles %}
 
-<div class="grid-benefits row col-sm-10 col-lg-8 col-center homepage-info">
+<div class="grid-benefits row col-sm-10 col-lg-8 col-center">
     {% if image1 %}
         <img class="grid-benefits__image grid-benefits__image1" src="{% static image1 %}">
     {% endif %}

--- a/portal/templates/portal/play_aimmo.html
+++ b/portal/templates/portal/play_aimmo.html
@@ -42,9 +42,7 @@
     </section>
 </div>
 <section class="background">
-    <div class="row col-sm-10 col-lg-8 col-center homepage-info">
-        {% benefits %}
-    </div>
+    {% benefits %}
 </section>
 <div class="background">
     <section class="banner--aimmo--video--container">

--- a/portal/templates/portal/play_rapid-router.html
+++ b/portal/templates/portal/play_rapid-router.html
@@ -45,9 +45,7 @@
     <section>
         {% headline headline_name="HEADLINE" %}
     </section>
-    <div class="row row--small homepage-info">
-        {% benefits %}
-    </div>
+    {% benefits %}
 </div>
 
 <section class="background background--quaternary">

--- a/portal/tests/snapshots/snap_test_partials.py
+++ b/portal/tests/snapshots/snap_test_partials.py
@@ -9,7 +9,7 @@ snapshots = Snapshot()
 
 snapshots['TestPartials::test_benefits 1'] = '''
 
-<div class="grid-benefits">
+<div class="grid-benefits row col-sm-10 col-lg-8 col-center homepage-info">
     
     
     

--- a/portal/tests/snapshots/snap_test_partials.py
+++ b/portal/tests/snapshots/snap_test_partials.py
@@ -9,7 +9,7 @@ snapshots = Snapshot()
 
 snapshots['TestPartials::test_benefits 1'] = '''
 
-<div class="grid-benefits row col-sm-10 col-lg-8 col-center homepage-info">
+<div class="grid-benefits row col-sm-10 col-lg-8 col-center">
     
     
     


### PR DESCRIPTION
### Description ###
The benefits partial was adjusted for the new Kurono play page but the change didn't propagate to the other two places it's used in (teach page and play RR page). This PR makes the change present in the partial itself so it's applied across pages.

### Screenshots ###
<img width="1396" alt="Screenshot 2019-10-09 at 09 20 18" src="https://user-images.githubusercontent.com/30693435/66464620-3e600a00-ea77-11e9-8ef4-d1092d628f17.png">
<img width="1424" alt="Screenshot 2019-10-09 at 09 21 12" src="https://user-images.githubusercontent.com/30693435/66464622-3e600a00-ea77-11e9-8a7e-bbe4b96eefe0.png">
<img width="1380" alt="Screenshot 2019-10-09 at 09 25 03" src="https://user-images.githubusercontent.com/30693435/66464624-3e600a00-ea77-11e9-9a56-74e7c342f0cc.png">
