### PR TITLE
fix: remove deprecated function from admin login view

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
         - pip install selenium==2.53.6
         - python example_project/manage.py collectstatic --noinput --settings test_settings
       script:
-        - pytest
+        - pytest --cov=. --cov-report=xml
       after_success:
         - bash <(curl -s https://codecov.io/bash)
     - stage: deploy

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -224,7 +224,7 @@
                 "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
                 "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
             ],
-            "markers": "python_version == '2.7'",
+            "markers": "python_version < '3.4'",
             "version": "==1.1.6"
         },
         "eventlet": {
@@ -268,10 +268,10 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:0950e663cef6fea90642996a44aa402978657dea47c8a4fb47caae335379668d",
-                "sha256:18f35c5c4665edc3b44cabb7919b220c88e078d819b3aba447858dedf10e1e73"
+                "sha256:6e848a39ac52c73a108d82cdaab9172ff9493d821dde61ee263e7aa9577da6a7",
+                "sha256:88fac30e1fa88bc86fb15213d4173a3020e7785270fca7c1ffe1bbd6fdb1144e"
             ],
-            "version": "==4.44.2"
+            "version": "==4.44.4"
         },
         "idna": {
             "hashes": [
@@ -307,6 +307,13 @@
                 "sha256:552a91f381532e33cbd07c6a2655a21908088962bb8fa7239ecbcc6ad1140cc7"
             ],
             "version": "==1.5"
+        },
+        "phonenumbers": {
+            "hashes": [
+                "sha256:09d4e3ced954fffaf9d2a7d6296a3a875464bf36c99149089755a19707efabc7",
+                "sha256:c9c00b6917ee5052465d1d63907dd8be3cf1314b908c62a8853cdc1863f3a15a"
+            ],
+            "version": "==7.7.5"
         },
         "pillow": {
             "hashes": [
@@ -513,7 +520,7 @@
                 "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
                 "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
             ],
-            "markers": "python_version < '3.3'",
+            "markers": "python_version < '3.0'",
             "version": "==1.0.2"
         },
         "idna": {
@@ -559,7 +566,7 @@
                 "sha256:0ec8205a157c80d7acc301c0b18fbd5d44fe655968f5d947b6ecef5290fc35db",
                 "sha256:6cd9a47b597b37cc57de1c05e56fb1a1c9cc9fab04fe78c29acd090418529868"
             ],
-            "markers": "python_version < '3.4'",
+            "markers": "python_version < '3.6'",
             "version": "==2.3.5"
         },
         "pluggy": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -18,10 +18,10 @@
     "default": {
         "aimmo": {
             "hashes": [
-                "sha256:023cafbc41eaa50d8bc2aa48d9ee337b6db5cf1ad4e5cdc82f024277be68a795",
-                "sha256:4552eefba6cac67f299b65d012c12333b26b3259c97ac1e24a78b09b46b5f2d6"
+                "sha256:025be9f26849424aa97369b8cbed0011d7ce54e1111ee6b2cd6340d750f39aaa",
+                "sha256:4f010d3d474fb57f3987d375ed4f756cbe7e7e660bcc2eb670a0a44499c24d92"
             ],
-            "version": "==0.32.2"
+            "version": "==0.34.1"
         },
         "attrs": {
             "hashes": [
@@ -29,6 +29,13 @@
                 "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
             ],
             "version": "==19.3.0"
+        },
+        "babel": {
+            "hashes": [
+                "sha256:af92e6106cb7c55286b25b38ad7695f8b4efb36a90ba483d7f7a6628c46158ab",
+                "sha256:e86135ae101e31e2c8ec20a4e0c5220f4eed12487d5cf3f78be7e98d3a57fc28"
+            ],
+            "version": "==2.7.0"
         },
         "certifi": {
             "hashes": [
@@ -50,10 +57,10 @@
         },
         "django": {
             "hashes": [
-                "sha256:d4ef83bd326573c00972cb9429beb396d210341a636e4b816fc9b3f505c498bb",
-                "sha256:ffdc7e938391ae3c2ee8ff82e0b4444e4e6bb15c99d00770285233d42aaf33d6"
+                "sha256:215c27453f775b6b1add83a185f76c2e2ab711d17786a6704bd62eabd93f89e3",
+                "sha256:ffd89b89a2ee860ee521f054225044f52676825be4b61168d2842d44fcf457d3"
             ],
-            "version": "==1.10.8"
+            "version": "==1.11.24"
         },
         "django-appconf": {
             "hashes": [
@@ -93,10 +100,10 @@
         },
         "django-countries": {
             "hashes": [
-                "sha256:23c6b5455a2e68ed02601cee0d3c80481965d0c3a6bd2f07ca56902b0a4c55a6",
-                "sha256:5bdda9d2c3473b519371428d88517f29befad7e35dfc489e8b0f95cb2aa941dc"
+                "sha256:73476e80877936e072cf0935109590def986d528083c9c1a99c0291f68f7d08a",
+                "sha256:fdcbbd6cd4740614e07b48f30714a57b95033913108d4a878b5ac73dbf3708e0"
             ],
-            "version": "==3.4.1"
+            "version": "==5.4"
         },
         "django-forms-bootstrap": {
             "hashes": [
@@ -107,10 +114,10 @@
         },
         "django-formtools": {
             "hashes": [
-                "sha256:647a5855277dcf335902eeeeeba3056e439493e6b7de70b942c988a6d8d70e04",
-                "sha256:6cee6e7b8990898332af2c00020195aacd428bd97ff99d1ec02e9deec84d928c"
+                "sha256:7703793f1675aa6e871f9fed147e8563816d7a5b9affdc5e3459899596217f7c",
+                "sha256:cb2bd7c29c2104278e5a0e76f7ff256b9570acf11485d547ee0c1b35347359fb"
             ],
-            "version": "==1.0"
+            "version": "==2.1"
         },
         "django-foundation-icons": {
             "hashes": [
@@ -132,23 +139,23 @@
         },
         "django-js-reverse": {
             "hashes": [
-                "sha256:62c540d46b1de17adcbb80ea6ef7239b4ab9793fadae1595383b2be801b1af60",
-                "sha256:928273d0cab8425af1851e9cd0de96d54b60e844163deb39bf0fe3b0585705a4"
+                "sha256:2a392d169f44e30b883c30dfcfd917a14167ce8fe196c99d2385b31c90d77aa0",
+                "sha256:8134c2ab6307c945edfa90671ca65e85d6c1754d48566bdd6464be259cc80c30"
             ],
-            "version": "==0.6.1"
+            "version": "==0.9.1"
         },
         "django-otp": {
             "hashes": [
-                "sha256:0016baa0f11544aa3a709d1b4fca13d607397ae41025bdc4fdb8a7e80a39973c",
-                "sha256:fd9e787779c053ba77e47a6907539c01e8db41b09f99722793317ed9a4183b32"
+                "sha256:246b11ee38ec1cea2e2312311a830740d1a8d0384ba15e7b70e03f851d790157",
+                "sha256:cefbf5e7295498c767752d77828ce3f56cdb0373915e56fe4f87d99604742394"
             ],
-            "version": "==0.4.3"
+            "version": "==0.7.0"
         },
         "django-phonenumber-field": {
             "hashes": [
-                "sha256:f3b23af290d0f800945c44e0737bd32f3ee38f63e7ad7076450778fe682a52fe"
+                "sha256:8db9d2dc833678b163adabd593cda7ad1dede81a1c18f67c895701fc44dc44f1"
             ],
-            "version": "==0.7.2"
+            "version": "==1.3.0"
         },
         "django-pipeline": {
             "hashes": [
@@ -184,10 +191,10 @@
         },
         "django-two-factor-auth": {
             "hashes": [
-                "sha256:596ca6a8d6f71b1acc2b1aa5cd1d8e13f2ada8bfa5808f2b5aa07922eb2b55c9",
-                "sha256:91e730cb0984508b97d93e7d7547f7a1676651908982b6c00fa2d10b34cda2f2"
+                "sha256:1f27660e14db370f4bb2b666180f47f32b40234eaf82e05f2c9ace6160f4b4b6",
+                "sha256:2319cea6b1e1415471c9b9fd5efd1b2ff29c97a06418045c6e7df5d22cb6e373"
             ],
-            "version": "==1.5.0"
+            "version": "==1.6.2"
         },
         "djangorestframework": {
             "hashes": [
@@ -217,7 +224,7 @@
                 "sha256:6bd0f6ad48ec2aa117d3d141940d484deccda84d4fcd884f5c3d93c23ecd8c79",
                 "sha256:8ad8c4783bf61ded74527bffb48ed9b54166685e4230386a9ed9b1279e2df5b1"
             ],
-            "markers": "python_version < '3.4'",
+            "markers": "python_version == '2.7'",
             "version": "==1.1.6"
         },
         "eventlet": {
@@ -261,10 +268,10 @@
         },
         "hypothesis": {
             "hashes": [
-                "sha256:7385185ceeada55746a406a90fc84bfc22481fd570cc4bbcf8401ea93ce574e3",
-                "sha256:c32f79ba3b587a210de4f17e88d704b712c4301a554d4f5d7a67d01076dce1d0"
+                "sha256:0950e663cef6fea90642996a44aa402978657dea47c8a4fb47caae335379668d",
+                "sha256:18f35c5c4665edc3b44cabb7919b220c88e078d819b3aba447858dedf10e1e73"
             ],
-            "version": "==4.42.3"
+            "version": "==4.44.2"
         },
         "idna": {
             "hashes": [
@@ -275,25 +282,24 @@
         },
         "libsass": {
             "hashes": [
-                "sha256:175355d74bd040893d539154016153247ea9775d1655a36441c97a453887a0c0",
-                "sha256:3113ef32eaf3662c162c250db6883d7a5f177856bfd8bb632a147cb0a95e4fee",
-                "sha256:312d135e6bd1a137927fed781dab497c05930305265e3d3b1da3b3d916cd97a6",
-                "sha256:32f8322aad9b6b864b826adb5e193d704d5fb2c816f85a5cc5bf775730e5d024",
-                "sha256:4252e24c8869d6ce764052f200445331d1881b5c2d283d6131a30d0684b10403",
-                "sha256:517324814f81cd2642cb1e9fd772e8e50e336c7c8833d50535a731e5b4c84606",
-                "sha256:607ce32c3b31542e0bf1bc2409627dd7247a3849ba720ec34d23426b96346199",
-                "sha256:6124594e72ba216b00131795ad5ea5de1e0cf8784e63a01e0c6a4e4c13fc7914",
-                "sha256:6129063002fc8337b734f5963ac3eb01ead51e9c88c6d27e73ddc9236cb15b2e",
-                "sha256:6d392ecd6e4de2ccfa3b1953f2da8461a2b7c8c8c17c24e1c335ab3040671c1a",
-                "sha256:75b38c236be6ca03e3dd3789f3044180fc0836b7c9e4991fcc52a8570f47dc91",
-                "sha256:9c711d4e4d003fec7f98fe87bb1faf7d88e6d648356413d8b8d9d76bd1844089",
-                "sha256:b15a0e61bd54764e658bc6931015453fa34d954f87c3b6fd35624e13bcacf69d",
-                "sha256:bc0c80a4e233b6b791a7f6f99415ab877e8a4d3a45085b68981c97d74dbfc8bf",
-                "sha256:c22cdc37121b730e5fb87bc8d3eee8c4b1fe219a04d198a535fbd22895c99e27",
-                "sha256:c5ba74babfb3a6976611312e0026c4668913cdf05e009921e1f54146ccdc02a4",
-                "sha256:f5cfe2ba69bcee673227a85603f960c061bfa49daceead07b09d9af8f6fd6f57"
+                "sha256:003a65b4facb4c5dbace53fb0f70f61c5aae056a04b4d112a198c3c9674b31f2",
+                "sha256:0fd8b4337b3b101c6e6afda9112cc0dc4bacb9133b59d75d65968c7317aa3272",
+                "sha256:338e9ae066bf1fde874e335324d5355c52d2081d978b4f74fc59536564b35b08",
+                "sha256:4dcfd561fb100250b89496e1362b96f2cc804f689a59731eb0f94f9a9e144f4a",
+                "sha256:50778d4be269a021ba2bf42b5b8f6ff3704ab96a82175a052680bddf3ba7cc9f",
+                "sha256:6a51393d75f6e3c812785b0fa0b7d67c54258c28011921f204643b55f7355ec0",
+                "sha256:74acd9adf506142699dfa292f0e569fdccbd9e7cf619e8226f7117de73566e32",
+                "sha256:81a013a4c2a614927fd1ef7a386eddabbba695cbb02defe8f31cf495106e974c",
+                "sha256:845a9573b25c141164972d498855f4ad29367c09e6d76fad12955ad0e1c83013",
+                "sha256:8b5b6d1a7c4ea1d954e0982b04474cc076286493f6af2d0a13c2e950fbe0be95",
+                "sha256:9b59afa0d755089c4165516400a39a289b796b5612eeef5736ab7a1ebf96a67c",
+                "sha256:a7e685466448c9b1bf98243339793978f654a1151eb5c975f09b83c7a226f4c1",
+                "sha256:c93df526eeef90b1ea4799c1d33b6cd5aea3e9f4633738fb95c1287c13e6b404",
+                "sha256:e318f06f06847ff49b1f8d086ac9ebce1e63404f7ea329adab92f4f16ba0e00e",
+                "sha256:fc5f8336750f76f1bfae82f7e9e89ae71438d26fc4597e3ab4c05ca8fcd41d8a",
+                "sha256:fcb7ab4dc81889e5fc99cafbc2017bc76996f9992fc6b175f7a80edac61d71df"
             ],
-            "version": "==0.19.3"
+            "version": "==0.19.4"
         },
         "monotonic": {
             "hashes": [
@@ -301,13 +307,6 @@
                 "sha256:552a91f381532e33cbd07c6a2655a21908088962bb8fa7239ecbcc6ad1140cc7"
             ],
             "version": "==1.5"
-        },
-        "phonenumbers": {
-            "hashes": [
-                "sha256:09d4e3ced954fffaf9d2a7d6296a3a875464bf36c99149089755a19707efabc7",
-                "sha256:c9c00b6917ee5052465d1d63907dd8be3cf1314b908c62a8853cdc1863f3a15a"
-            ],
-            "version": "==7.7.5"
         },
         "pillow": {
             "hashes": [
@@ -370,6 +369,13 @@
             ],
             "version": "==1.8.3"
         },
+        "pytz": {
+            "hashes": [
+                "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
+                "sha256:b02c06db6cf09c12dd25137e563b31700d3b80fcc4ad23abb7a315f2789819be"
+            ],
+            "version": "==2019.3"
+        },
         "pyyaml": {
             "hashes": [
                 "sha256:ef3a0d5a5e950747f4a39ed7b204e036b37f9bddc7551c1a813b8727515a832e"
@@ -384,10 +390,10 @@
         },
         "rapid-router": {
             "hashes": [
-                "sha256:11e7fbf77b82d3d06ab63bb6c61d740e11160f1388e06abe89a67c9ffea7f3f1",
-                "sha256:70efedb8f4364e77f64e0b3b12bca26d9e98eff015fb6789b6e051455400fd9e"
+                "sha256:08cb49e82e270333121a7d9d76f9b40b42f42e9dd563446a2eda52c86af36772",
+                "sha256:a37ac3256268975dcd6e349e35974282737e00e70d7970d327692e9357ed91e1"
             ],
-            "version": "==2.1.7"
+            "version": "==2.2.0"
         },
         "reportlab": {
             "hashes": [
@@ -484,10 +490,10 @@
         },
         "django": {
             "hashes": [
-                "sha256:d4ef83bd326573c00972cb9429beb396d210341a636e4b816fc9b3f505c498bb",
-                "sha256:ffdc7e938391ae3c2ee8ff82e0b4444e4e6bb15c99d00770285233d42aaf33d6"
+                "sha256:215c27453f775b6b1add83a185f76c2e2ab711d17786a6704bd62eabd93f89e3",
+                "sha256:ffd89b89a2ee860ee521f054225044f52676825be4b61168d2842d44fcf457d3"
             ],
-            "version": "==1.10.8"
+            "version": "==1.11.24"
         },
         "django-selenium-clean": {
             "hashes": [
@@ -572,10 +578,10 @@
         },
         "pyparsing": {
             "hashes": [
-                "sha256:6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80",
-                "sha256:d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
             ],
-            "version": "==2.4.2"
+            "version": "==2.4.5"
         },
         "pytest": {
             "hashes": [
@@ -586,11 +592,11 @@
         },
         "pytest-django": {
             "hashes": [
-                "sha256:497e8d967d2ec82b3388267b2f1f037761ff34c10ebb13c534d8c5804846e4eb",
-                "sha256:b6c900461a6a7c450dcf11736cabc289a90f5d6f28ef74c46e32e86ffd16a4bd"
+                "sha256:17592f06d51c2ef4b7a0fb24aa32c8b6998506a03c8439606cb96db160106659",
+                "sha256:ef3d15b35ed7e46293475e6f282e71a53bcd8c6f87bdc5d5e7ad0f4d49352127"
             ],
             "index": "pypi",
-            "version": "==3.6.0"
+            "version": "==3.7.0"
         },
         "pytz": {
             "hashes": [

--- a/portal/app_settings.py
+++ b/portal/app_settings.py
@@ -35,9 +35,8 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 from django.conf import settings
-import os
 
-CONTACT_FORM_EMAILS = getattr(settings, "PORTAL_CONTACT_FORM_EMAIL", ("",))
+CONTACT_FORM_EMAILS = getattr(settings, "PORTAL_CONTACT_FORM_EMAIL", ("codeforlife@ocado.com",))
 
 #: Email address to source notifications from
 EMAIL_ADDRESS = getattr(settings, "EMAIL_ADDRESS", "no-reply@codeforlife.education")

--- a/portal/forms/admin_login.py
+++ b/portal/forms/admin_login.py
@@ -47,5 +47,5 @@ class AdminLoginForm(AuthenticationForm):
 
     def __init__(self, user, *args, **kwargs):
         super(AdminLoginForm, self).__init__(user, *args, **kwargs)
-        if not AdminLoginForm.is_captcha_visible:
+        if not self.is_captcha_visible:
             remove_captcha_from_form(self)

--- a/portal/forms/admin_login.py
+++ b/portal/forms/admin_login.py
@@ -34,8 +34,9 @@
 # copyright notice and these terms. You must not misrepresent the origins of this
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
-from django.contrib.auth.forms import AuthenticationForm
 from captcha.fields import ReCaptchaField
+from django.contrib.auth.forms import AuthenticationForm
+
 from portal.helpers.captcha import remove_captcha_from_form
 
 
@@ -44,7 +45,7 @@ class AdminLoginForm(AuthenticationForm):
 
     is_captcha_visible = False
 
-    def __init__(self, user, *args, **kwags):
-        super(AdminLoginForm, self).__init__(user, *args, **kwags)
+    def __init__(self, user, *args, **kwargs):
+        super(AdminLoginForm, self).__init__(user, *args, **kwargs)
         if not AdminLoginForm.is_captcha_visible:
             remove_captcha_from_form(self)

--- a/portal/static/portal/sass/old_styles.scss
+++ b/portal/static/portal/sass/old_styles.scss
@@ -657,7 +657,7 @@ ul.topNav li.selected a
 
 
 /************** admin login **************/
-#admin_login {
+#administration_login {
   margin:120px;
 }
 /************** end admin login **************/

--- a/portal/templates/registration/login.html
+++ b/portal/templates/registration/login.html
@@ -32,9 +32,9 @@
                 </tr>
                 <tr>
                     <td colspan="2">
-                        {# {% if captcha %} #}
+                        {% if captcha %}
                             {{ form.captcha }}
-                        {# {% endif %} #}
+                        {% endif %}
                     </td>
                 </tr>
             </table>

--- a/portal/templates/registration/login.html
+++ b/portal/templates/registration/login.html
@@ -2,13 +2,13 @@
 {% load static %}
 
 {% block content %}
-<div id="admin_login">
+<div id="administration_login">
 <div class="span_centered_half">
     <div class="login-card">
         <h3>Admin login</h3><br/>
         <p>This is for site admins to log in, if you are not part of the codeforlife development team then this is not the login form you are looking for.</p>
 
-        <form method="post" action="{% url 'admin_login' %}">
+        <form method="post" action="{% url 'administration_login' %}">
 
             {% csrf_token %}
 

--- a/portal/tests/pageObjects/portal/admin/admin_login_page.py
+++ b/portal/tests/pageObjects/portal/admin/admin_login_page.py
@@ -34,7 +34,6 @@
 # copyright notice and these terms. You must not misrepresent the origins of this
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
-from django.core.exceptions import PermissionDenied
 from portal.tests.pageObjects.portal.admin.admin_base_page import AdminBasePage
 
 
@@ -42,7 +41,7 @@ class AdminLoginPage(AdminBasePage):
     def __init__(self, browser, live_server_url):
         super(AdminLoginPage, self).__init__(browser, live_server_url)
 
-        assert self.on_correct_page("admin_login")
+        assert self.on_correct_page("administration_login")
 
     def login_to_forbidden(self, username, password):
         self._login(username, password)

--- a/portal/tests/pageObjects/portal/base_page.py
+++ b/portal/tests/pageObjects/portal/base_page.py
@@ -117,7 +117,7 @@ class BasePage(object):
         return aimmo_home_page.AimmoHomePage(self.browser)
 
     def is_on_admin_login_page(self):
-        return self.on_correct_page("admin_login")
+        return self.on_correct_page("administration_login")
 
     def is_on_admin_data_page(self):
         return self.on_correct_page("admin_data")

--- a/portal/tests/test_admin.py
+++ b/portal/tests/test_admin.py
@@ -35,13 +35,14 @@
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
 import uuid
+
 from django.contrib.auth.models import User, Permission
 from django.core.urlresolvers import reverse
 
-from portal.tests.pageObjects.portal.admin.admin_login_page import AdminLoginPage
-from portal.tests.base_test import BaseTest
-from portal.views import admin
 from portal.models import UserProfile
+from portal.tests.base_test import BaseTest
+from portal.tests.pageObjects.portal.admin.admin_login_page import AdminLoginPage
+from portal.views import admin
 
 
 class TestAdmin(BaseTest):
@@ -52,7 +53,7 @@ class TestAdmin(BaseTest):
 
     # NB: Users are not expected to navigate to admin login page directly
     def navigate_to_admin_login(self):
-        url = self.live_server_url + reverse("admin_login")
+        url = self.live_server_url + reverse("administration_login")
         self.selenium.get(url)
         return AdminLoginPage(self.selenium, self.live_server_url)
 

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -52,7 +52,7 @@ from two_factor.views import (
 
 from portal.permissions import teacher_verified
 from portal.views.about import about
-from portal.views.admin import aggregated_data, schools_map, admin_login
+from portal.views.admin import aggregated_data, schools_map, AdminLoginView
 from portal.views.aimmo.home import aimmo_home
 from portal.views.play_aimmo import play_aimmo
 from portal.views.api import (
@@ -168,12 +168,11 @@ urlpatterns = [
         r"^favicon\.ico$",
         RedirectView.as_view(url="/static/portal/img/favicon.ico", permanent=True),
     ),
-    url(r"^administration/login/$", admin_login, name="administration_login"),
+    url(r"^administration/login/$", AdminLoginView.as_view(), name="administration_login"),
     url(
         r"^admin/$",
         RedirectView.as_view(url=reverse_lazy("aggregated_data"), permanent=True),
     ),
-    url(r"^admin/login/$", admin_login, name="admin_login"),
     url(r"^admin/map/$", schools_map, name="map"),
     url(r"^admin/data/$", aggregated_data, name="aggregated_data"),
     url(r"^mail/weekly", send_new_users_report, name="send_new_users_report"),

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -41,6 +41,7 @@ from django.views.generic import RedirectView
 from django.views.generic.base import TemplateView
 from django.views.i18n import javascript_catalog
 from game.views.level import play_default_level
+from two_factor.urls import urlpatterns as two_factor_urls
 from two_factor.views import (
     DisableView,
     BackupTokensView,
@@ -53,8 +54,8 @@ from two_factor.views import (
 from portal.permissions import teacher_verified
 from portal.views.about import about
 from portal.views.admin import aggregated_data, schools_map, AdminLoginView
+from portal.views.admin import is_post_request
 from portal.views.aimmo.home import aimmo_home
-from portal.views.play_aimmo import play_aimmo
 from portal.views.api import (
     registered_users,
     last_connected_since,
@@ -76,6 +77,7 @@ from portal.views.organisation import (
     organisation_manage,
     organisation_leave,
 )
+from portal.views.play_aimmo import play_aimmo
 from portal.views.play_landing_page import play_landing_page
 from portal.views.play_rapid_router import play_rapid_router
 from portal.views.privacy_policy import privacy_policy
@@ -126,7 +128,7 @@ from portal.views.teacher.teach import (
 from portal.views.teacher.teacher_materials import materials
 from portal.views.teacher.teacher_resources import teacher_resources
 from portal.views.terms import terms
-from two_factor.urls import urlpatterns as two_factor_urls
+from ratelimit.decorators import ratelimit
 
 js_info_dict = {"packages": ("conf.locale",)}
 
@@ -168,7 +170,13 @@ urlpatterns = [
         r"^favicon\.ico$",
         RedirectView.as_view(url="/static/portal/img/favicon.ico", permanent=True),
     ),
-    url(r"^administration/login/$", AdminLoginView.as_view(), name="administration_login"),
+    url(
+        r"^administration/login/$",
+        ratelimit("def", periods=["1m"], increment=is_post_request)(
+            AdminLoginView.as_view()
+        ),
+        name="administration_login",
+    ),
     url(
         r"^admin/$",
         RedirectView.as_view(url=reverse_lazy("aggregated_data"), permanent=True),

--- a/portal/views/admin.py
+++ b/portal/views/admin.py
@@ -68,7 +68,7 @@ def admin_login(request):
         and captcha.CAPTCHA_ENABLED
     )
     AdminLoginForm.is_captcha_visible = show_captcha
-    return auth_views.login(
+    return auth_views.LoginView.as_view()(
         request,
         authentication_form=AdminLoginForm,
         extra_context={"captcha": show_captcha, "settings": app_settings},

--- a/portal/views/admin.py
+++ b/portal/views/admin.py
@@ -81,9 +81,10 @@ class AdminLoginView(LoginView):
 
     def get_form(self, form_class=None):
         self.populate_context_dict()
-        AdminLoginForm.is_captcha_visible = self.show_captcha()
         user = self.request.user
-        return self.form_class(user, **self.get_form_kwargs())
+        form = self.form_class(user, **self.get_form_kwargs())
+        form.is_captcha_visible = self.show_captcha()
+        return form
 
 
 @login_required(login_url=reverse_lazy("administration_login"))

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = test_settings
-addopts = -p no:warnings --cov=. --cov-report=xml
+addopts = -p no:warnings

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         "sqlparse",
         "libsass",
         "django-forms-bootstrap",
+        "phonenumbers==7.7.5"
     ],
     zip_safe=False,
 )


### PR DESCRIPTION
## Description
This PR fixes an issue that arose within the admin login view after the Django 1.11 upgrade.
The problem was that the login function in Django's auth.views is now deprecated and replaced with a class called LoginView instead. More details [here](https://docs.djangoproject.com/en/1.11/topics/auth/default/#all-authentication-views).