### PR TITLE
fix: cache templates with version

### DIFF
--- a/portal/templates/portal/base.html
+++ b/portal/templates/portal/base.html
@@ -17,7 +17,7 @@
     {% endblock head %}
 
     {% block css %}
-    {% cache 3600 fragment-base_new-css %}
+    {% cache 3600 fragment-base_new-css get_project_version %}
     <link href="{% static 'portal.css' %}" type="text/css" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Baloo" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro" rel="stylesheet">
@@ -26,7 +26,7 @@
     {% endcache %}
     {% endblock css %}
 
-    {% cache 3600 fragment-base_new-javascript %}
+    {% cache 3600 fragment-base_new-javascript get_project_version %}
     <script type="text/javascript" src="{% static 'portal/js/lib/jquery.js' %}"></script>
     <script type="text/javascript" src="{% static 'portal/js/lib/jquery-ui.js' %}"></script>
     <script type="text/javascript" src="{% static 'portal/js/bootstrap.js' %}"></script>
@@ -274,7 +274,7 @@
 {% endblock contentWrapper %}
 
 {% block footer %}
-{% cache 3600 fragment-base_new-footer %}
+{% cache 3600 fragment-base_new-footer get_project_version %}
 <div class="footer">
     <a id="back_to_top_button" class="back-to-top" href="#top"><img class="no-padding" src="{% static 'portal/img/footer_arrow.png' %}"></a>
     <p><a href="#top"><small>BACK TO TOP</small></a></p>

--- a/portal/templates/portal/base_old.html
+++ b/portal/templates/portal/base_old.html
@@ -18,7 +18,7 @@
 
     {% block css %}
     <link href="{% static 'portal/css/common.css' %}" rel="stylesheet">
-    {% cache 3600 fragment-base-css %}
+    {% cache 3600 fragment-base-css-old get_project_version %}
     <link href="{% static 'portal/css/jquery-ui.css' %}" rel="stylesheet">
     <link href="{% static 'portal/css/jquery-ui.structure.css' %}" rel="stylesheet">
     <link href="{% static 'portal/css/jquery-ui.theme.css' %}" rel="stylesheet">
@@ -33,7 +33,7 @@
     {% endcache %}
     {% endblock css %}
 
-    {% cache 3600 fragment-base_new-javascript %}
+    {% cache 3600 fragment-base_old-javascript get_project_version %}
     <script type="text/javascript" src="{% static 'portal/js/lib/jquery.js' %}"></script>
     <script type="text/javascript" src="{% static 'portal/js/lib/jquery-ui.js' %}"></script>
     <script type="text/javascript" src="{% static 'portal/js/bootstrap.js' %}"></script>
@@ -247,7 +247,7 @@
 {% endblock contentWrapper %}
 
 {% block footer %}
-{% cache 3600 fragment-base_new-footer %}
+{% cache 3600 fragment-base_old-footer %}
 <div class="footer">
     <a id="back_to_top_button" class="back-to-top" href="#top"><img class="no-padding" src="{% static 'portal/img/footer_arrow.png' %}"></a>
     <p><a href="#top"><small>BACK TO TOP</small></a></p>

--- a/portal/templates/portal/teach/materials.html
+++ b/portal/templates/portal/teach/materials.html
@@ -33,7 +33,7 @@
 {% block content %}
 {{ block.super }}
 
-{% cache 3600 fragment-materials-page %}
+{% cache 3600 fragment-materials-page get_project_version %}
 <div id="materials_page"></div>
 
 <div id="user_guide">


### PR DESCRIPTION
Now that the global cache prefix no longer has the version in it, I have made sure the django html templates are still versioned in the cache.

Signed-off-by: Niket Shah <masterniket@gmail.com>