### PR TITLE
fix: pass in kwargs in materials viewer redirect 

### DIFF
--- a/portal/tests/conftest.py
+++ b/portal/tests/conftest.py
@@ -1,0 +1,51 @@
+from collections import namedtuple
+
+import pytest
+from aimmo.models import Game
+from common.models import Class
+from common.tests.utils.classes import create_class_directly
+from common.tests.utils.student import (
+    create_independent_student_directly,
+    create_school_student_directly,
+)
+from common.tests.utils.teacher import signup_teacher_directly
+from portal.tests.utils.organisation import create_organisation_directly
+
+from .utils.aimmo_games import create_aimmo_game_directly
+from .utils.worksheets import create_worksheet_directly
+
+SchoolStudent = namedtuple("student", ["username", "password"])
+IndependentStudent = namedtuple("independent_student", ["username", "password"])
+TeacherLoginDetails = namedtuple("teacher", ["email", "password"])
+
+
+@pytest.fixture
+def teacher1(db) -> TeacherLoginDetails:
+    return TeacherLoginDetails(*signup_teacher_directly())
+
+
+@pytest.fixture
+def class1(db, teacher1: TeacherLoginDetails) -> Class:
+    create_organisation_directly(teacher1.email)
+    klass, _, _ = create_class_directly(teacher1.email)
+    return klass
+
+
+@pytest.fixture
+def student1(db, class1) -> SchoolStudent:
+    username, password, _ = create_school_student_directly(class1.access_code)
+    return SchoolStudent(username, password)
+
+
+@pytest.fixture
+def independent_student1(db) -> IndependentStudent:
+    username, password, _ = create_independent_student_directly()
+    return IndependentStudent(username, password)
+
+
+@pytest.fixture
+def aimmo_game1(db, class1) -> Game:
+    worksheet = create_worksheet_directly()
+    worksheet.student_pdf_name = "TestPDFName"
+    worksheet.save()
+    return create_aimmo_game_directly(class1, worksheet)

--- a/portal/tests/test_aimmo_dashboards.py
+++ b/portal/tests/test_aimmo_dashboards.py
@@ -1,56 +1,10 @@
-from collections import namedtuple
-
 import pytest
 from aimmo.models import Game
 from common.models import Class
-from common.tests.utils.classes import create_class_directly
-from common.tests.utils.student import (
-    create_school_student_directly,
-    create_independent_student_directly,
-)
-from common.tests.utils.teacher import signup_teacher_directly
 from django.test.client import Client
 from django.urls.base import reverse
 
-from portal.tests.utils.organisation import create_organisation_directly
-from .utils.aimmo_games import create_aimmo_game_directly
-from .utils.worksheets import create_worksheet_directly
-
-SchoolStudent = namedtuple("student", ["username", "password"])
-IndependentStudent = namedtuple("independent_student", ["username", "password"])
-
-
-@pytest.fixture
-def teacher1_email(db) -> str:
-    teacher_email, _ = signup_teacher_directly()
-    return teacher_email
-
-
-@pytest.fixture
-def class1(db, teacher1_email) -> Class:
-    create_organisation_directly(teacher1_email)
-    klass, _, _ = create_class_directly(teacher1_email)
-    return klass
-
-
-@pytest.fixture
-def student1(db, class1) -> SchoolStudent:
-    username, password, _ = create_school_student_directly(class1.access_code)
-    return SchoolStudent(username, password)
-
-
-@pytest.fixture
-def independent_student1(db) -> IndependentStudent:
-    username, password, _ = create_independent_student_directly()
-    return IndependentStudent(username, password)
-
-
-@pytest.fixture
-def aimmo_game1(db, class1) -> Game:
-    worksheet = create_worksheet_directly()
-    worksheet.student_pdf_name = "TestPDFName"
-    worksheet.save()
-    return create_aimmo_game_directly(class1, worksheet)
+from .conftest import IndependentStudent, SchoolStudent
 
 
 @pytest.mark.django_db

--- a/portal/tests/test_materials.py
+++ b/portal/tests/test_materials.py
@@ -77,9 +77,7 @@ class MaterialsTests(TestCase):
         assert result == [("KS1_S3_1", "KS1 S3 1")]
 
 
-def test_materials_viewer_redirect(
-    live_server, client: Client, teacher1: TeacherLoginDetails
-):
+def test_materials_viewer_redirect(client: Client, teacher1: TeacherLoginDetails):
     client.login(email=teacher1.email, password=teacher1.password)
     response = client.get(
         reverse("materials_viewer_redirect", kwargs={"pdf_name": "KS1_S3_1"}),

--- a/portal/tests/test_materials.py
+++ b/portal/tests/test_materials.py
@@ -34,10 +34,12 @@
 # copyright notice and these terms. You must not misrepresent the origins of this
 # program; modified versions of the program must be marked as such and not
 # identified as the original program.
-from django.test import TestCase
-
-from portal.templatetags.table_tags import resource_sheets_table, lengthen_list
+from django.test import Client, TestCase
+from django.urls.base import reverse
+from portal.templatetags.table_tags import lengthen_list, resource_sheets_table
 from portal.views.materials_viewer import get_links
+
+from .conftest import TeacherLoginDetails
 
 
 class MaterialsTests(TestCase):
@@ -73,3 +75,14 @@ class MaterialsTests(TestCase):
         pdf_name = "KS1_session_3"
         result = get_links(pdf_name)
         assert result == [("KS1_S3_1", "KS1 S3 1")]
+
+
+def test_materials_viewer_redirect(
+    live_server, client: Client, teacher1: TeacherLoginDetails
+):
+    client.login(email=teacher1.email, password=teacher1.password)
+    response = client.get(
+        reverse("materials_viewer_redirect", kwargs={"pdf_name": "KS1_S3_1"}),
+        follow=True,
+    )
+    assert response.status_code == 200

--- a/portal/urls.py
+++ b/portal/urls.py
@@ -317,7 +317,7 @@ urlpatterns = [
     url(
         r"^teach/materials/(?P<pdf_name>[a-zA-Z0-9\/\-_]+)$",
         materials_viewer_redirect,
-        name="materials_viewer",
+        name="materials_viewer_redirect",
     ),
     url(
         r"^materials/(?P<pdf_name>[a-zA-Z0-9\/\-_]+)$",

--- a/portal/views/teacher/__init__.py
+++ b/portal/views/teacher/__init__.py
@@ -3,4 +3,4 @@ from django.core.urlresolvers import reverse_lazy
 
 
 def materials_viewer_redirect(request, pdf_name):
-    return redirect(reverse_lazy("materials_viewer", args=pdf_name))
+    return redirect(reverse_lazy("materials_viewer", kwargs={"pdf_name": pdf_name}))


### PR DESCRIPTION
This bug fix allows teachers who have saved the previous URL for teaching resources to redirect successfully to the new URL