### PR TITLE
fix: include templates in common manifest

### DIFF
--- a/cfl_common/MANIFEST.in
+++ b/cfl_common/MANIFEST.in
@@ -1,1 +1,2 @@
 include common/fixtures/*.json
+graft common/templates


### PR DESCRIPTION
This fixes other packages using common templates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/1420)
<!-- Reviewable:end -->
