### PR TITLE
fix: mobile navbar buttons max width, padding, Ocado logo, account icon, dropdown

### DIFF
--- a/portal/static/portal/sass/partials/_buttons.scss
+++ b/portal/static/portal/sass/partials/_buttons.scss
@@ -298,6 +298,7 @@ button,
   &:after {
     @include _font-size(24px);
     @include _padding(0px, 0px, 0px, $spacing * 5);
+    font-weight: normal;
     line-height: 1;
     content: "\e5cf";
     font-family: "Material Icons Outlined";
@@ -382,7 +383,7 @@ button,
   .dropdown {
     width: 100%;
   }
-  
+
   .button--dropdown {
     border: none;
     margin: 0;

--- a/portal/static/portal/sass/partials/_header.scss
+++ b/portal/static/portal/sass/partials/_header.scss
@@ -144,7 +144,8 @@
     height: 100%;
   }
 
-  button {
+  button,
+  .dropdown-menu {
     max-width: 350px;
   }
 }

--- a/portal/static/portal/sass/partials/_header.scss
+++ b/portal/static/portal/sass/partials/_header.scss
@@ -327,7 +327,24 @@
   #menu-items {
     button,
     .button {
+      @include _padding(0px, $spacing * 3, 0px, $spacing * 3);
       max-width: none;
+
+      &.login {
+        padding-left: calculate-rem($spacing * 4);
+      }
+
+      &.button--menu__item__sub {
+        padding-left: calculate-rem($spacing * 6);
+      }
+
+      &.button--menu__item__sub__sub {
+        padding-left: calculate-rem($spacing * 10);
+      }
+    }
+
+    #login-tabs > .button {
+      padding-left: calculate-rem($spacing * 2);
     }
   }
 }

--- a/portal/static/portal/sass/partials/_header.scss
+++ b/portal/static/portal/sass/partials/_header.scss
@@ -323,6 +323,13 @@
     align-items: center;
     display: inline;
   }
+
+  #menu-items {
+    button,
+    .button {
+      max-width: none;
+    }
+  }
 }
 
 @media (max-width: $mobile-max-width) {

--- a/portal/static/portal/sass/partials/_header.scss
+++ b/portal/static/portal/sass/partials/_header.scss
@@ -205,10 +205,6 @@
       @include _padding($spacing * 3, $spacing * 9, $spacing * 3, $spacing * 3);
     }
 
-    .menu__brand {
-      @include _margin(0px, $spacing * 7, 0px, 0px);
-    }
-
     .menu__brand--ocado {
       img {
         height: 42px;
@@ -299,6 +295,10 @@
       justify-content: space-between;
       align-items: center;
       height: 100%;
+
+      .menu__brand--ocado {
+        margin-right: 33px; // align Ocado logo to the middle of the screen
+      }
     }
 
     .logo {


### PR DESCRIPTION
## Before
![dev-dot-decent-digit-629 appspot com_](https://user-images.githubusercontent.com/67904187/131713630-fdedc9c0-db9e-4ced-aba5-d8cfb1a3c3c6.png)

## After
![localhost_8000_](https://user-images.githubusercontent.com/67904187/131831289-816169e2-cd0c-4178-8f33-08abb5a36ce9.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/1520)
<!-- Reviewable:end -->
