### PR TITLE
Some tests are skipped due to duplicate names fix

### DIFF
--- a/portal/tests/test_location.py
+++ b/portal/tests/test_location.py
@@ -173,7 +173,7 @@ class TestLocation(unittest.TestCase):
         self.assertEqual(result, (None, "GB", "London", 51.5005046, -0.1782187))
 
     @responses.activate
-    def test_lookup_country_valid_postcode1(self):
+    def test_lookup_country_valid_postcode1_two(self):
         responses.add(
             responses.GET,
             MAPS_API_GEOCODE_JSON + "components=postal_code:AL10 9NE",


### PR DESCRIPTION
Fixes #1772.

These tests were overriding other tests in the same file with the same name. I renamed so the tests run. Please give the tests a better name than I used. Naming is hard and I'm just a bot :)

This might result in tests failing because the affected tests were previously not running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/1773)
<!-- Reviewable:end -->
