### PR TITLE
fix: update broken blockly documentation link

### DIFF
--- a/portal/templates/portal/play.html
+++ b/portal/templates/portal/play.html
@@ -29,7 +29,7 @@
             </div>
             <div class="row my-4">
                 <div class="col-sm-12">
-                    <a href="https://docs.codeforlife.education/rapid-router/blockly-guide"
+                    <a href="https://code-for-life.gitbook.io/rapid-router/blockly-guide"
                        class="button button--primary button--icon col-sm-8"
                        target="_blank">
                         Learn more about Blockly<span class="iconify" data-icon="mdi:open-in-new"></span></a>


### PR DESCRIPTION
This is the Blockly link in the "Starting with Blockly" section on the "Play" page!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/2346)
<!-- Reviewable:end -->
