### PR TITLE
Fixes #2383, #2422, and #2423

### DIFF
--- a/portal/templates/portal/contribute.html
+++ b/portal/templates/portal/contribute.html
@@ -38,9 +38,9 @@
 </div>
 
 <div class="background background--primary">
-    <div class="row">
-        <div class="container d-flex flex-row">
-            <div class="col-sm-6">
+    <div class="container">
+        <div class="row d-flex flex-column-reverse flex-md-row">
+            <div class="col-12 col-md-6 order-1 order-md-0">
                 <h4>Our products</h4>
 
                 <p><b>The website</b></p>
@@ -61,9 +61,9 @@
                     Python experience to a foundation in Python, helping
                     prepare them for GCSE and beyond.</p>
             </div>
-            <div class="col-sm-6">
+            <div class="col-12 col-md-6 order-0 order-md-1">
                 <img title="Rapid Router" alt="Rapid Router"
-                     src="{% static 'portal/img/rapidrouter.png' %}">
+                     src="{% static 'portal/img/rapidrouter.png' %}" class="img-fluid">
             </div>
         </div>
     </div>

--- a/portal/templates/portal/partials/header.html
+++ b/portal/templates/portal/partials/header.html
@@ -147,7 +147,7 @@
             </div>
         {% else %}
         <div class="menu__right-side col-md-5">
-            <a href="{% url 'register' %}" id="signup_button" class="button button--primary button--register register">Register</a>
+            <a href="{% url 'register' %}" id="signup_button" class="button button--primary button--register register">Register for FREE</a>
             <div class="dropdown">
                 <button id="login_dropdown" class="button--regular button--secondary button--header--login button--dropdown"
                         data-toggle="dropdown">
@@ -238,7 +238,7 @@
             {% endif %}
         {% else %}
             <a class="button button--menu__item button--register"
-              href="{% url 'register' %}">Register now</a>
+              href="{% url 'register' %}">Register now for FREE</a>
             <button class="button--menu__item button--menu__item--sub-header login"
                     data-toggle="collapse" data-target="#login-tabs">Log in</button>
             <div id="login-tabs" class="collapse">

--- a/portal/templates/portal/register.html
+++ b/portal/templates/portal/register.html
@@ -9,11 +9,11 @@
             <div id="teacher-register-form" class="form-div form">
                 <h4>Teacher/Tutor</h4>
                 <div class="row form--row">
-                    <p class="semi-bold">Register below to create your school or club.</p>
+                    <p class="semi-bold">Register below to create your free account.</p>
                     <small class="semi-bold">You will have access to teaching resources, progress tracking and lesson plans
                     for Rapid Router.</small>
                 </div>
-                <form class="d-flex flex-column"
+                <form class="d-flex flex-column" 
                       method="post"
                       id="form-reg-teacher"
                       autocomplete="off">
@@ -87,10 +87,7 @@
             <div id="independent-student-register-form" class="form-div">
                 <h4>Independent learner</h4>
                 <div class="row form--row">
-                    <p class="semi-bold">
-                        Register below if you are not part of a school or club and wish to set up a home
-                        learning account.
-                    </p>
+                    <p class="semi-bold">Register below if you are not part of a school or club and wish to set up a free home learning account.</p>
                     <small class="semi-bold">You will have access to learning resources for Rapid Router.</small>
                 </div>
                 <form id="form-signup-independent-student"


### PR DESCRIPTION
<!--- This template can be modified slightly to the needs of the pull request -->

## #2383 | Responsiveness issue in Contribute page
rapidrouter.png now shifts above the text when page is in mobile view.

Desktop:
![image](https://github.com/user-attachments/assets/f179440a-91d2-43ae-97da-e74f3178489a)

Mobile:
![image](https://github.com/user-attachments/assets/013aedaa-c65a-45d4-893a-66ad5897f4e9)

## #2422 | Update Register button in Nav bar
- [x] Change text to 'Register for FREE'
- [x] Check tablet and mobile formatting - if issue with length, leave as 'Register' on smaller devices # No issues with tablet or mobile formatting, also updated alt register button intended for tablet/mobile views

Desktop:
![image](https://github.com/user-attachments/assets/d3163b2a-2dbc-4d18-8c6d-0e9b2119b2c2)

Tablet/Mobile:
![image](https://github.com/user-attachments/assets/040538ab-304c-4690-95de-9e895000a108)

## #2423 | Amend text on Register page
- [x] Amend text in teacher registration form
- [x] Amend text in Independent registration form

![image](https://github.com/user-attachments/assets/52438e66-e6b2-4357-b0b6-7512c7f4e393)
![image](https://github.com/user-attachments/assets/c3f39bbe-3b9d-4619-979a-51c034e0da46)

I have noticed that values in portal-frontend/TeacherForm.tsx + IndyForm.tsx (specifically subheader within BaseForm) were shared with the text that I have now altered. Will this need resolving through a pull request to codeforlife-portal-frontend?