### PR TITLE
fix: Fix for #2432

### DIFF
--- a/portal/templates/portal/teach.html
+++ b/portal/templates/portal/teach.html
@@ -130,7 +130,7 @@
                     <p>
                         See how Rapid Router fits into
                         <a href="https://docs.codeforlife.education/national-curriculum-alignment" target="_blank">
-                            English national curriculum &mdash; the computer science strand
+                            the English national curriculum &mdash; the computer science strand
                             <span class="iconify" data-icon="mdi:open-in-new"></span></a>
                         and
                         <a href="https://docs.codeforlife.education/national-curriculum-alignment-1" target="_blank">

--- a/portal/templates/portal/teach.html
+++ b/portal/templates/portal/teach.html
@@ -129,11 +129,11 @@
                     </p>
                     <p>
                         See how Rapid Router fits into
-                        <a href="https://code-for-life.gitbook.io/teaching-resources/rapid-router-resources/introduction-to-coding-england" target="_blank">
+                        <a href="https://docs.codeforlife.education/national-curriculum-alignment" target="_blank">
                             English national curriculum &mdash; the computer science strand
                             <span class="iconify" data-icon="mdi:open-in-new"></span></a>
                         and
-                        <a href="https://code-for-life.gitbook.io/teaching-resources/rapid-router-resources/introduction-to-coding-scotland" target="_blank">
+                        <a href="https://docs.codeforlife.education/national-curriculum-alignment-1" target="_blank">
                             the Scottish curriculum.
                             <span class="iconify" data-icon="mdi:open-in-new"></span>
                         </a>


### PR DESCRIPTION
## #2432 | New links in Teacher landing page
Linked new docs to teacher landing page. Couldn't find the relevant gitbook files within the repo so am unable to remove the now redundant pages from my end.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ocadotechnology/codeforlife-portal/2433)
<!-- Reviewable:end -->
